### PR TITLE
Ffmpeg reconnect, other minor fixes

### DIFF
--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
@@ -34,18 +34,12 @@ public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> implements Runn
 
     private Thread reconnectThread;
 
-    private boolean manualStop = false;
     private int currentReconnect;
-
-    public FFMPEGSensor() {
-        currentReconnect = 0;
-    }
 
     @Override
     protected void doInit() throws SensorHubException {
         super.doInit();
         currentReconnect = 0;
-        manualStop = false;
 
         // We need the background thread here since we start reading the video data immediately in order to determine
         // the video size.
@@ -115,54 +109,6 @@ public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> implements Runn
         }
         handleReconnect();
 
-/*
-        int currentReconnect = 0;
-        long prevTime;
-        boolean reconnected = true;
-        while (!Thread.interrupted() && currentReconnect < config.connectionConfig.reconnectAttempts) {
-            reconnected = true;
-            prevTime = System.currentTimeMillis();
-            try {
-                super.doStop();
-            } catch (SensorHubException e) {
-                logger.info("Error stopping module from reconnect thread.");
-            }
-            try {
-                doStart();
-            } catch (SensorHubException e) {
-                logger.info("Reconnect {} failed.", currentReconnect + 1);
-                reconnected = false;
-            }
-
-            if (reconnected) {
-                currentReconnect = 0;
-                try {
-                    mpegTsProcessor.join();
-                } catch (InterruptedException e) {
-                    logger.info("Reconnect thread interrupted.");
-                    return;
-                }
-            } else {
-                currentReconnect++;
-                try {
-                    Thread.sleep(Math.max(0, prevTime - System.currentTimeMillis() + config.connectionConfig.reconnectPeriod));
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        }
-
-
-        if (config.connectionConfig.reconnectAttempts > 0) {
-            logger.error("Reconnect failed after {} attempts.", currentReconnect);
-        }
-
-        try {
-            this.getParentHub().getModuleRegistry().stopModuleAsync(this);
-        } catch (SensorHubException e) {
-            throw new RuntimeException(e);
-        }
-*/
     }
 
     @Override

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensor.java
@@ -14,7 +14,11 @@
 package org.sensorhub.impl.sensor.ffmpeg;
 
 import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.module.ModuleEvent;
+import org.sensorhub.impl.module.ModuleRegistry;
 import org.sensorhub.impl.sensor.ffmpeg.config.FFMPEGConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Sensor driver that can read video data that is compatible with FFMPEG.
@@ -23,10 +27,25 @@ import org.sensorhub.impl.sensor.ffmpeg.config.FFMPEGConfig;
  * @author Drew Botts
  * @since Feb. 2023
  */
-public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> {
+public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> implements Runnable {
+
+    /** Debug logger */
+    private static final Logger logger = LoggerFactory.getLogger(FFMPEGSensor.class);
+
+    private Thread reconnectThread;
+
+    private boolean manualStop = false;
+    private int currentReconnect;
+
+    public FFMPEGSensor() {
+        currentReconnect = 0;
+    }
+
     @Override
     protected void doInit() throws SensorHubException {
         super.doInit();
+        currentReconnect = 0;
+        manualStop = false;
 
         // We need the background thread here since we start reading the video data immediately in order to determine
         // the video size.
@@ -40,7 +59,6 @@ public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> {
     @Override
     protected void doStart() throws SensorHubException {
     	super.doStart();
-
     	// Start up the background thread if it's not already going. Normally doInit() will have just been called, so
     	// this is redundant (but harmless). But if the user has stopped the sensor and re-started it, then this call
     	// is necessary.
@@ -48,10 +66,113 @@ public class FFMPEGSensor extends FFMPEGSensorBase<FFMPEGConfig> {
 
         // Make sure the stream is already open. (If the sensor has been previously started, then stopped, then the
         // stream won't be open.)
-        openStream();
+        try {
+            openStream();
+        } catch (SensorHubException e) {
+            handleReconnect();
+            return;
+        }
 
         // Some preliminary data was read from the stream in doInit(), but this call makes it start processing all the
         // frames.
         startStream();
+
+        currentReconnect = 0;
+        reconnectThread = new Thread(this);
+        if (!reconnectThread.isAlive()) {
+            reconnectThread.start();
+        }
+    }
+
+    private void handleReconnect() {
+        if (currentReconnect < config.connectionConfig.reconnectAttempts) {
+            try {
+                logger.info("Reconnect attempt {}.", currentReconnect + 1);
+                this.getParentHub().getModuleRegistry().restartModuleAsync(this);
+                currentReconnect++;
+            } catch (SensorHubException e) {
+                throw new RuntimeException(e);
+            }
+        } else {
+            logger.error("Failed to connect after {} attempts.", currentReconnect);
+            currentReconnect = 0;
+            try {
+                this.getParentHub().getModuleRegistry().stopModuleAsync(this);
+            } catch (SensorHubException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            mpegTsProcessor.join();
+        } catch (InterruptedException e) {
+            logger.info("Mpeg process interrupted.");
+            currentReconnect = 0;
+            return;
+        }
+        handleReconnect();
+
+/*
+        int currentReconnect = 0;
+        long prevTime;
+        boolean reconnected = true;
+        while (!Thread.interrupted() && currentReconnect < config.connectionConfig.reconnectAttempts) {
+            reconnected = true;
+            prevTime = System.currentTimeMillis();
+            try {
+                super.doStop();
+            } catch (SensorHubException e) {
+                logger.info("Error stopping module from reconnect thread.");
+            }
+            try {
+                doStart();
+            } catch (SensorHubException e) {
+                logger.info("Reconnect {} failed.", currentReconnect + 1);
+                reconnected = false;
+            }
+
+            if (reconnected) {
+                currentReconnect = 0;
+                try {
+                    mpegTsProcessor.join();
+                } catch (InterruptedException e) {
+                    logger.info("Reconnect thread interrupted.");
+                    return;
+                }
+            } else {
+                currentReconnect++;
+                try {
+                    Thread.sleep(Math.max(0, prevTime - System.currentTimeMillis() + config.connectionConfig.reconnectPeriod));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+
+
+        if (config.connectionConfig.reconnectAttempts > 0) {
+            logger.error("Reconnect failed after {} attempts.", currentReconnect);
+        }
+
+        try {
+            this.getParentHub().getModuleRegistry().stopModuleAsync(this);
+        } catch (SensorHubException e) {
+            throw new RuntimeException(e);
+        }
+*/
+    }
+
+    @Override
+    public void doStop() throws SensorHubException {
+        try {
+            reconnectThread.interrupt();
+        } catch (SecurityException e) {
+            logger.info("Reconnect thread interrupted.");
+        }
+        super.doStop();
+
     }
 }

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
@@ -200,12 +200,11 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
 	            Asserts.checkArgument(config.connection.fps >= 0, "FPS must be >= 0");
 	            mpegTsProcessor = new MpegTsProcessor(config.connection.transportStreamPath, config.connection.fps, config.connection.loop);
 	        } else if ((null != config.connection.connectionString) && (!config.connection.connectionString.isBlank())) {
-	            mpegTsProcessor = new MpegTsProcessor(config.connection.connectionString);
+	            mpegTsProcessor = new MpegTsProcessor(config.connection.connectionString, config.connection.fps, false);
 	        } else {
 	        	throw new SensorHubException("Either the input file path or the connection string must be set");
 	        }
-            mpegTsProcessor.setReconnect(config.connectionConfig.reconnectAttempts, config.connectionConfig.connectTimeout,
-                    config.connectionConfig.reconnectPeriod);
+            mpegTsProcessor.setTimeout(config.connectionConfig.connectTimeout * 1000L);
 	        
 	        if (mpegTsProcessor.openStream()) {
 	        	logger.info("Stream opened for {}", getUniqueIdentifier());
@@ -223,7 +222,7 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
 	                mpegTsProcessor.setVideoDataBufferListener(videoOutput);
 	            }
 	        } else {
-	        	//throw new SensorHubException("Unable to open stream from data source");
+	        	throw new SensorHubException("Unable to open stream from data source");
                 //return false;
 	        }
 

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
@@ -2,8 +2,11 @@ package org.sensorhub.impl.sensor.ffmpeg;
 
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 
 import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.event.Event;
+import org.sensorhub.api.event.IEventListener;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.DefaultLocationOutput;
 import org.sensorhub.impl.sensor.DefaultLocationOutputLLA;
@@ -38,6 +41,11 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
      * Background thread manager. Used for image decoding. At the moment, this is a single thread.
      */
     protected ScheduledExecutorService executor;
+
+    /**
+     *
+     */
+    protected int currentReconnect;
 
     /**
      * Sensor output for the video frames.
@@ -196,6 +204,8 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
 	        } else {
 	        	throw new SensorHubException("Either the input file path or the connection string must be set");
 	        }
+            mpegTsProcessor.setReconnect(config.connectionConfig.reconnectAttempts, config.connectionConfig.connectTimeout,
+                    config.connectionConfig.reconnectPeriod);
 	        
 	        if (mpegTsProcessor.openStream()) {
 	        	logger.info("Stream opened for {}", getUniqueIdentifier());
@@ -213,14 +223,13 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
 	                mpegTsProcessor.setVideoDataBufferListener(videoOutput);
 	            }
 	        } else {
-	        	throw new SensorHubException("Unable to open stream from data source");
+	        	//throw new SensorHubException("Unable to open stream from data source");
+                //return false;
 	        }
-	
 
-
-		        
 	    	logger.info("MPEG TS stream for {} opened.", getUniqueIdentifier());
     	}
+        //return true;
     }
 
     /**
@@ -300,6 +309,7 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
         isMJPEG = config.connection.isMJPEG;
         return isMJPEG;
     }
-    
+
+
 
 }

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/Connection.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/Connection.java
@@ -31,7 +31,7 @@ public class Connection {
     
     @DisplayInfo(label = "FPS", desc = "Number of frames per second to enforce during playback of a file."
         + " 0 means the stream will be played as fast as possible.")
-    public int fps = 0;
+    public int fps = 60;
     
     @DisplayInfo(desc = "Continuously loop video playback (only available when reading from file).")
     public boolean loop = false;

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/FFMPEGConfig.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/config/FFMPEGConfig.java
@@ -16,6 +16,8 @@ package org.sensorhub.impl.sensor.ffmpeg.config;
 import org.sensorhub.api.config.DisplayInfo;
 import org.sensorhub.api.sensor.PositionConfig;
 import org.sensorhub.api.sensor.SensorConfig;
+import org.sensorhub.impl.comm.RobustIPConnectionConfig;
+import org.sensorhub.impl.module.RobustConnectionConfig;
 
 /**
  * Configuration settings for the FFMPEG driver exposed via the OpenSensorHub Admin panel.
@@ -52,5 +54,7 @@ public class FFMPEGConfig extends SensorConfig {
     {
         return positionConfig.location;
     }
+
+    public RobustConnectionConfig connectionConfig = new RobustConnectionConfig();
 
 }

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
@@ -179,7 +179,7 @@ public class Video<FFMPEGConfigType extends FFMPEGConfig> extends AbstractSensor
             }
 
             if (Boolean.TRUE.equals(ignoreDataTimestamp)){
-                dataBlock.setDoubleValue(0, System.currentTimeMillis()/1000);
+                dataBlock.setDoubleValue(0, (double) System.currentTimeMillis() /1000);
             } else {
 
                 double sampleTime = syncTime.getPrecisionTimeStamp() + (record.getPresentationTimestamp() - syncTime.getPresentationTimeStamp());

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
@@ -104,6 +104,7 @@ public class Video<FFMPEGConfigType extends FFMPEGConfig> extends AbstractSensor
         }
 
 
+
         dataStruct = outputDef.getElementType();
         dataStruct.setLabel(SENSOR_OUTPUT_LABEL);
         dataStruct.setDescription(SENSOR_OUTPUT_DESCRIPTION);


### PR DESCRIPTION
Allows for reconnecting the video stream by restarting the driver. Also, added connection timeout and fps functionality for non-file stream.