### PR TITLE
41: Add ffmpeg initial config for axis and sony cameras

### DIFF
--- a/processing/sensorhub-process-occupancy/src/main/java/com/botts/impl/process/occupancy/OccupancyDataRecorder.java
+++ b/processing/sensorhub-process-occupancy/src/main/java/com/botts/impl/process/occupancy/OccupancyDataRecorder.java
@@ -138,7 +138,12 @@ public class OccupancyDataRecorder extends ExecutableProcessImpl implements ISen
             return false;
 
         outputData.clear();
-        db.getDataStreamStore().values().forEach(ds -> {
+        var sysFilter = new SystemFilter.Builder()
+                .withUniqueIDs(inputSystemID)
+                .includeMembers(true)
+                .build();
+
+        db.getDataStreamStore().select(new DataStreamFilter.Builder().withSystems(sysFilter).build()).forEach(ds -> {
             // Don't add process datastreams as outputs
             if(ds.getSystemID().getUniqueID().contains(OSHProcessInfo.URI_PREFIX))
                 return;

--- a/processing/sensorhub-process-occupancy/src/main/java/com/botts/impl/process/occupancy/OccupancyProcessModule.java
+++ b/processing/sensorhub-process-occupancy/src/main/java/com/botts/impl/process/occupancy/OccupancyProcessModule.java
@@ -20,17 +20,22 @@ import net.opengis.swe.v20.AbstractSWEIdentifiable;
 import net.opengis.swe.v20.DataComponent;
 import net.opengis.swe.v20.DataEncoding;
 import org.sensorhub.api.ISensorHub;
+import org.sensorhub.api.command.ICommandReceiver;
 import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.data.IDataProducer;
+import org.sensorhub.api.datastore.command.CommandStreamFilter;
 import org.sensorhub.api.datastore.obs.DataStreamFilter;
 import org.sensorhub.api.datastore.system.SystemFilter;
+import org.sensorhub.api.event.Event;
 import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.processing.OSHProcessInfo;
 import org.sensorhub.api.processing.ProcessingException;
 import org.sensorhub.api.utils.OshAsserts;
+import org.sensorhub.impl.module.ModuleRegistry;
 import org.sensorhub.impl.processing.AbstractProcessModule;
 import com.botts.impl.process.occupancy.helpers.ProcessHelper;
 import com.botts.impl.process.occupancy.helpers.OccupancyDataOutputInterface;
-import org.sensorhub.impl.sensor.SensorSystem;
+import org.sensorhub.utils.Async;
 import org.vast.process.ProcessException;
 import org.vast.sensorML.AggregateProcessImpl;
 import org.vast.sensorML.SMLException;
@@ -39,7 +44,10 @@ import org.vast.sensorML.SMLUtils;
 
 import java.io.*;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.Flow;
+import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 // Based on SMLProcessImpl
@@ -51,7 +59,8 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
     protected boolean useThreads = true;
     String processUniqueID;
     OccupancyDataRecorder alarmProcess;
-    String parentSystemUniqueID;
+    String parentSystemUID = null;
+    Flow.Subscription subscription = null;
 
     /**
      * Standalone processing module to be recognized by OSH module provider, accessible in the OSH Admin UI.
@@ -75,6 +84,23 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
 
     @Override
     protected void doInit() throws SensorHubException {
+        parentSystemUID = config.systemUID;
+        if (parentSystemUID == null || parentSystemUID.isBlank()) {
+            if(getParentSystem() == null || getParentSystemUID() == null || getParentSystemUID().isBlank())
+                throw new SensorHubException("Please specify a system UID, or put process under parent system.");
+            parentSystemUID = getParentSystemUID();
+        }
+
+        // Listen for system events on config's system UID
+        getParentHub().getEventBus().newSubscription()
+                // TODO: Ideally should only listen to single module, but we would need to change config or programmatically find the lane module
+                .withTopicID(ModuleRegistry.EVENT_GROUP_ID)
+                .consume(this::handleEvent)
+                .thenAccept(s -> {
+                    subscription = s;
+                    s.request(Long.MAX_VALUE);
+                });
+
         try {
             processUniqueID = OSHProcessInfo.URI_PREFIX +  "occupancy:" + config.serialNumber;
             OshAsserts.checkValidUID(processUniqueID);
@@ -91,6 +117,54 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
         }
     }
 
+    private void handleEvent(Event e) {
+        if (e instanceof ModuleEvent event) {
+            // Subsystem has been added to our parent system containing RPM and other data sources
+            if (event.getModule() instanceof IDataProducer driver && Objects.equals(driver.getParentSystemUID(), parentSystemUID)
+            && event.getType().equals(ModuleEvent.Type.STATE_CHANGED)
+            && event.getNewState().equals(ModuleEvent.ModuleState.STARTED)
+            && this.isStarted()) {
+                try {
+                    Async.waitForCondition(() -> checkSystemDriverFinishedRegistration(driver.getUniqueIdentifier(), driver), 500, 10000);
+                    new Thread(() -> {
+                        boolean isStarting = true;
+                        while (isStarting) {
+                            try {
+                                this.init();
+                                boolean isInitialized = waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
+                                if (!isInitialized)
+                                    continue;
+                                this.start();
+                                isStarting = false;
+                            } catch (SensorHubException ex) {
+                                getLogger().info("Failed restart, trying again to restart module...");
+                            }
+                        }
+                    }).start();
+                } catch (TimeoutException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+    }
+
+    private boolean checkSystemDriverFinishedRegistration(String systemUID, IDataProducer driver) {
+        var dsFilter = new DataStreamFilter.Builder().withSystems(new SystemFilter.Builder().withUniqueIDs(systemUID).build()).build();
+        var numDataStreams = getParentHub().getDatabaseRegistry().getFederatedDatabase().getDataStreamStore().countMatchingEntries(dsFilter);
+        var numDriverOutputs = driver.getOutputs().size();
+
+        boolean outputsMatch = numDriverOutputs == numDataStreams;
+
+        if (driver instanceof ICommandReceiver commandReceiver) {
+            var csFilter = new CommandStreamFilter.Builder().withSystems(new SystemFilter.Builder().withUniqueIDs(systemUID).build()).build();
+            var numControlStreams = getParentHub().getDatabaseRegistry().getFederatedDatabase().getCommandStreamStore().countMatchingEntries(csFilter);
+            var numDriverInputs = commandReceiver.getCommandInputs().size();
+            return outputsMatch && numControlStreams == numDriverInputs;
+        }
+
+        return outputsMatch;
+    }
+
     /**
      * Build SensorML process description via ProcessHelper. // TODO Change to use ProcessHelper in sensorhub-process-helpers
      * @return process chain implementation to be executed
@@ -98,18 +172,12 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
      * @throws SensorHubException if no RPM data streams
      */
     public AggregateProcessImpl buildProcess() throws ProcessException, SensorHubException {
-        String systemUID = config.systemUID;
-        if (systemUID == null || systemUID.isBlank()) {
-            if(getParentSystem() == null || getParentSystemUID() == null || getParentSystemUID().isBlank())
-                throw new SensorHubException("Please specify a system UID, or put process under parent system.");
-            systemUID = getParentSystemUID();
-        }
 
         ProcessHelper processHelper = new ProcessHelper();
         processHelper.getAggregateProcess().setUniqueIdentifier(processUniqueID);
 
         var sysFilter = new SystemFilter.Builder()
-                .withUniqueIDs(systemUID)
+                .withUniqueIDs(parentSystemUID)
                 .includeMembers(true)
                 .build();
 
@@ -121,7 +189,7 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
                 .withLimit(1)
                 .build());
 
-        var dsList = matchingDs.collect(Collectors.toList());
+        var dsList = matchingDs.toList();
         if(dsList.size() != 1)
             throw new SensorHubException("Unable to find RPM datastream in system");
         var rpmDs = dsList.get(0);
@@ -134,7 +202,7 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
 
         processHelper.addDataSource("source0", dataStreamUID);
 
-        alarmProcess.getParameterList().getComponent(OccupancyDataRecorder.SYSTEM_INPUT_PARAM).getData().setStringValue(systemUID);
+        alarmProcess.getParameterList().getComponent(OccupancyDataRecorder.SYSTEM_INPUT_PARAM).getData().setStringValue(parentSystemUID);
 
         alarmProcess.setParentHub(getParentHub());
         alarmProcess.notifyParamChange();
@@ -181,12 +249,6 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
         refreshIOList(processDescription.getOutputList(), outputs, alarmProcess.getOutputEncodingMap());
 
         setState(ModuleEvent.ModuleState.INITIALIZED);
-    }
-
-
-    public AggregateProcessImpl getProcessChain()
-    {
-        return wrapperProcess;
     }
 
 
@@ -256,6 +318,11 @@ public class OccupancyProcessModule extends AbstractProcessModule<OccupancyProce
     @Override
     protected void doStop()
     {
+        if (subscription != null) {
+            subscription.cancel();
+            subscription = null;
+        }
+
         if (wrapperProcess != null && wrapperProcess.isExecutable())
             wrapperProcess.stop();
     }

--- a/sensors/sensorhub-driver-aspect/build.gradle
+++ b/sensors/sensorhub-driver-aspect/build.gradle
@@ -1,5 +1,5 @@
 description = 'Aspect Sensor Driver'
-ext.details = "Aspect Portal Monitor Sensor Driver"
+ext.details = "Aspect Radiation Portal Monitor (RPM) Sensor Driver"
 version = '1.0.0'
 
 dependencies {

--- a/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/AspectSensor.java
+++ b/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/AspectSensor.java
@@ -291,6 +291,7 @@ public class AspectSensor extends AbstractSensorModule<AspectConfig> implements 
         synchronized (this) {
             while (isRunning) {
                 if(messageHandler.getTimeSinceLastMessage() < config.commSettings.connection.reconnectPeriod) {
+
                     this.connectionStatusOutput.onNewMessage(true);
                 }
                 else {

--- a/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/MessageHandler.java
+++ b/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/MessageHandler.java
@@ -50,7 +50,7 @@ public class MessageHandler {
         occupancyGammaBatch = new LinkedList<>();
         occupancyNeutronBatch = new LinkedList<>();
 
-        timeSinceLastMessage = System.currentTimeMillis();
+
 
 //        thread = new Thread(this, "Message Handler");
 
@@ -63,6 +63,8 @@ public class MessageHandler {
 
                 MonitorRegisters monitorRegisters = new MonitorRegisters(parentSensor.commProviderModule.getConnection(), 100, 21);
                 while (!Thread.currentThread().isInterrupted()) {
+                    timeSinceLastMessage = System.currentTimeMillis();
+
                     monitorRegisters.readRegisters(deviceAddress);
 
                     double timestamp = System.currentTimeMillis() / 1000d;
@@ -73,7 +75,6 @@ public class MessageHandler {
                     parentSensor.gammaOutput.setData(monitorRegisters, timestamp);
                     parentSensor.neutronOutput.setData(monitorRegisters, timestamp);
                     parentSensor.speedOutput.setData(monitorRegisters, timestamp);
-
 
                     if (checkOccupancyRecord(monitorRegisters, timestamp)) {
                         parentSensor.occupancyOutput.setData(monitorRegisters, timestamp, startTime, endTime, gammaAlarm, neutronAlarm, maxGamma, maxNeutron);

--- a/sensors/sensorhub-driver-ffmpeg/build.gradle
+++ b/sensors/sensorhub-driver-ffmpeg/build.gradle
@@ -1,5 +1,5 @@
-description = 'FFMPEG VIDEO DRIVER'
-ext.details = "Driver for connecting to ffmpeg capable video streams"
+description = 'FFmpeg Video Driver'
+ext.details = "Driver for connecting to FFmpeg capable video streams"
 version = '2.0.0'
 
 // To build in entire java cv platform of projects use

--- a/sensors/sensorhub-driver-kromek-d3s/build.gradle
+++ b/sensors/sensorhub-driver-kromek-d3s/build.gradle
@@ -1,5 +1,5 @@
 description = 'Kromek D3S Radiation Sensor Driver'
-ext.details = "Radiation Sensor Driver"
+ext.details = "Driver for the Kromek D3S radiation sensor."
 version = '1.0.0'
 
 dependencies {
@@ -20,7 +20,7 @@ test {
 // add info to OSGi manifest
 osgi {
     manifest {
-        attributes ('Bundle-Vendor': 'Botts Inc')
+        attributes ('Bundle-Vendor': 'Botts Innovative Research, Inc.')
         attributes ('Bundle-Activator': 'com.botts.impl.sensor.kromek.d3s.D3sActivator')
     }
 }

--- a/sensors/sensorhub-driver-kromek-d5/build.gradle
+++ b/sensors/sensorhub-driver-kromek-d5/build.gradle
@@ -1,4 +1,4 @@
-description = 'Kromek D5'
+description = 'Kromek D5 Radiation Sensor Driver'
 ext.details = 'Driver for the Kromek D5 radiation sensor.'
 version = '1.0.0'
 
@@ -24,7 +24,7 @@ test {
 // add info to OSGi manifest
 osgi {
     manifest {
-        attributes ('Bundle-Vendor': 'Botts Inc')
+        attributes ('Bundle-Vendor': 'Botts Innovative Research, Inc.')
         attributes ('Bundle-Activator': 'com.botts.impl.sensor.kromek.d5.D5Activator')
     }
 }

--- a/sensors/sensorhub-driver-rapiscan/build.gradle
+++ b/sensors/sensorhub-driver-rapiscan/build.gradle
@@ -1,5 +1,5 @@
 description = 'Rapiscan Sensor Driver'
-ext.details = "Radiation Portal Monitor Sensor Driver"
+ext.details = "Rapiscan Radiation Portal Monitor (RPM) Sensor Driver"
 version = '1.0.0'
 
 dependencies {
@@ -22,7 +22,7 @@ test {
 // add info to OSGi manifest
 osgi {
     manifest {
-        attributes ('Bundle-Vendor': 'Botts Inc')
+        attributes ('Bundle-Vendor': 'Botts Innovative Research, Inc.')
         attributes ('Bundle-Activator': 'com.botts.impl.sensor.rapiscan.RapiscanActivator')
     }
 }

--- a/sensors/sensorhub-driver-rapiscan/src/main/java/com/botts/impl/sensor/rapiscan/EMLConfig.java
+++ b/sensors/sensorhub-driver-rapiscan/src/main/java/com/botts/impl/sensor/rapiscan/EMLConfig.java
@@ -10,7 +10,7 @@ public class EMLConfig {
     @DisplayInfo(label = "Is Collimated", desc = "Collimation status")
     public boolean isCollimated = false;
 
-    @DisplayInfo(label = "Lane Width", desc = "Width of the lane")
+    @DisplayInfo(label = "Lane Width (m)", desc = "Width of the lane in meters")
     public double laneWidth = 4.82f;
 
 }

--- a/sensors/sensorhub-driver-rs350/build.gradle
+++ b/sensors/sensorhub-driver-rs350/build.gradle
@@ -1,6 +1,6 @@
-description = 'RS-350'
+description = 'RS-350 Radiation Sensor Driver'
 ext.details = ''
-version = '0.1'
+version = '1.0.0'
 
 dependencies {
     implementation 'org.sensorhub:sensorhub-core:' + oshCoreVersion

--- a/sensors/sensorhub-system-lane/build.gradle
+++ b/sensors/sensorhub-system-lane/build.gradle
@@ -10,7 +10,8 @@ dependencies {
     implementation project(':sensorhub-driver-rapiscan')
     implementation project(':sensorhub-driver-videocam')
     implementation project(':sensorhub-process-occupancy')
-    testImplementation project(':sensorhub-driver-fakeweather')
+    // NOTE: Uncomment and use if you want to run specific lane module unit tests
+//    testImplementation project(':sensorhub-driver-fakeweather')
     testImplementation('junit:junit:4.13.1')
     implementation('junit:junit:4.13.1')
 }

--- a/sensors/sensorhub-system-lane/build.gradle
+++ b/sensors/sensorhub-system-lane/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     implementation project(':sensorhub-driver-rapiscan')
     implementation project(':sensorhub-driver-videocam')
     implementation project(':sensorhub-process-occupancy')
+    testImplementation project(':sensorhub-driver-fakeweather')
     testImplementation('junit:junit:4.13.1')
     implementation('junit:junit:4.13.1')
 }

--- a/sensors/sensorhub-system-lane/build.gradle
+++ b/sensors/sensorhub-system-lane/build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':sensorhub-process-occupancy')
     // NOTE: Uncomment and use if you want to run specific lane module unit tests
 //    testImplementation project(':sensorhub-driver-fakeweather')
+    implementation project(':sensorhub-driver-ffmpeg')
     testImplementation('junit:junit:4.13.1')
     implementation('junit:junit:4.13.1')
 }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/Descriptor.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/Descriptor.java
@@ -32,7 +32,7 @@ public class Descriptor extends JarModuleProvider implements IModuleProvider {
 
     @Override
     public String getModuleDescription() {
-        return "RPM Lane Sensor System to be used as parent system for RPM and Video drivers that are part of a lane.";
+        return "Specialized Sensor System module to be used as parent system for RPM and Video drivers in a lane.";
     }
 
     @Override

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
@@ -26,35 +26,24 @@ import com.botts.impl.sensor.rapiscan.RapiscanSensor;
 import com.botts.impl.system.lane.config.LaneConfig;
 import com.botts.impl.system.lane.config.LaneDatabaseConfig;
 import com.botts.impl.system.lane.config.RPMConfig;
-import org.sensorhub.api.command.ICommandReceiver;
 import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.api.data.IDataProducer;
 import org.sensorhub.api.database.IObsSystemDatabase;
-import org.sensorhub.api.datastore.command.CommandStreamFilter;
-import org.sensorhub.api.datastore.obs.DataStreamFilter;
-import org.sensorhub.api.datastore.system.SystemFilter;
 import org.sensorhub.api.event.Event;
 import org.sensorhub.api.event.EventUtils;
 import org.sensorhub.api.module.ModuleConfig;
 import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.api.sensor.SensorConfig;
-import org.sensorhub.api.system.SystemAddedEvent;
 import org.sensorhub.api.system.SystemRemovedEvent;
 import org.sensorhub.impl.comm.TCPCommProviderConfig;
-import org.sensorhub.impl.database.system.MaxAgeAutoPurgeConfig;
 import org.sensorhub.impl.database.system.SystemDriverDatabase;
 import org.sensorhub.impl.module.AbstractModule;
+import org.sensorhub.impl.module.ModuleRegistry;
 import org.sensorhub.impl.processing.AbstractProcessModule;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.SensorSystem;
 import org.sensorhub.impl.sensor.SensorSystemConfig;
-import org.sensorhub.impl.sensor.videocam.VideoCamHelper;
 import org.sensorhub.impl.system.SystemDatabaseTransactionHandler;
-import org.sensorhub.utils.Async;
 import org.sensorhub.utils.MsgUtils;
-import org.sensorhub.utils.NamedThreadFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.vast.util.Asserts;
 
 import java.util.ArrayList;
@@ -74,17 +63,20 @@ public class LaneSystem extends SensorSystem {
     private static final String RAPISCAN_URI = URN_PREFIX + "osh:sensor:rapiscan";
     private static final String ASPECT_URI = URN_PREFIX + "osh:sensor:aspect";
     private static final String PROCESS_URI = URN_PREFIX + "osh:process:occupancy";
+
+    private static final Object databaseLock = new Object();
+
     AbstractSensorModule<?> existingRPMModule = null;
     AbstractProcessModule<?> existingProcessModule = null;
     Flow.Subscription subscription = null;
     private ExecutorService threadPool = null;
     private BlockingQueue<Runnable> execQueue = null;
-    Logger logger = LoggerFactory.getLogger(LaneSystem.class);
 
     @Override
     protected void doInit() throws SensorHubException {
         execQueue = new LinkedBlockingQueue<>(100);
-        threadPool = new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, execQueue, new NamedThreadFactory("LaneModuleThreadPool"));
+//        threadPool = new ThreadPoolExecutor(1, 1, 10, TimeUnit.SECONDS, execQueue, new NamedThreadFactory("LaneModuleThreadPool"));
+        threadPool = Executors.newSingleThreadExecutor();
 
         // generate unique ID
         if (config.uniqueID != null && !config.uniqueID.equals(AUTO_ID)) {
@@ -141,7 +133,7 @@ public class LaneSystem extends SensorSystem {
         if (existingRPMModule == null)
             statusMsg += "No RPM driver found in lane.\n";
         if (existingProcessModule == null && !registeringProcessModule)
-            statusMsg += "No database process module found in lane.\n";
+            statusMsg += "No database process module found for this lane.\n";
         if (!statusMsg.equalsIgnoreCase("Note: "))
             reportStatus(statusMsg);
 
@@ -166,7 +158,6 @@ public class LaneSystem extends SensorSystem {
                 processConfig.serialNumber = config.uniqueID;
                 processConfig.name = getConfiguration().name + " Database Process";
                 processConfig.systemUID = getUniqueIdentifier();
-                // TODO: Set autostart == lane autostart
                 try {
                     existingProcessModule = (AbstractProcessModule<?>) getParentHub().getModuleRegistry().loadModule(processConfig);
                     reportStatus("Process module loaded with module ID " + existingProcessModule.getLocalID());
@@ -178,35 +169,13 @@ public class LaneSystem extends SensorSystem {
 
         getParentHub().getEventBus().newSubscription()
             // TODO: osh-core needs to use EventUtils for module topic IDs
-            .withTopicID(EventUtils.getSystemRegistryTopicID(), getLocalID())
+            .withTopicID(EventUtils.getSystemRegistryTopicID(), ModuleRegistry.EVENT_GROUP_ID)
             .subscribe(this::handleLaneEvent)
             .thenAccept(subscription -> {
                 this.subscription = subscription;
                 subscription.request(Long.MAX_VALUE);
                 getLogger().info("Started module subscription to {}", getLocalID());
             });
-    }
-
-    private boolean checkDriverFinishedRegistration(String systemUID, IDataProducer driver) {
-        var dsFilter = new DataStreamFilter.Builder().withSystems(new SystemFilter.Builder().withUniqueIDs(systemUID).build()).build();
-        var numDataStreams = getParentHub().getDatabaseRegistry().getFederatedDatabase().getDataStreamStore().countMatchingEntries(dsFilter);
-        var numDriverOutputs = driver.getOutputs().size();
-
-        boolean outputsMatch = numDriverOutputs == numDataStreams;
-
-        if (driver instanceof ICommandReceiver commandReceiver) {
-            var csFilter = new CommandStreamFilter.Builder().withSystems(new SystemFilter.Builder().withUniqueIDs(systemUID).build()).build();
-            var numControlStreams = getParentHub().getDatabaseRegistry().getFederatedDatabase().getCommandStreamStore().countMatchingEntries(csFilter);
-            var numDriverInputs = commandReceiver.getCommandInputs().size();
-            return outputsMatch && numControlStreams == numDriverInputs;
-        }
-
-        return outputsMatch;
-    }
-
-    @Override
-    protected void doStop() throws SensorHubException {
-        super.doStop();
     }
 
     @Override
@@ -225,7 +194,7 @@ public class LaneSystem extends SensorSystem {
                 // Auto delete process module and remove from database
                 if (existingProcessModule != null) {
                     var processDesc = existingProcessModule.getCurrentDescription();
-                    String processUID = null;
+                    String processUID;
                     if (processDesc == null)
                         processUID = createProcessUID(config.uniqueID);
                     else
@@ -238,7 +207,7 @@ public class LaneSystem extends SensorSystem {
                     removalList.add(processUID);
                 }
                 // Remove lane (and process) from database
-                removeSystemsFromDatabase(laneDatabaseId, true, removalList);
+                deleteSystemsFromDatabase(laneDatabaseId, removalList);
             }
         }
 
@@ -257,33 +226,13 @@ public class LaneSystem extends SensorSystem {
         return URN_PREFIX + "osh:process:occupancy:" + suffix;
     }
 
-    private void addSystemsToDatabase(String databaseId, List<String> systemUIDs) {
+    private synchronized void deleteSystemsFromDatabase(String databaseId, List<String> systemUIDs) {
         try {
-            if (getParentHub().getModuleRegistry().getModuleById(databaseId) instanceof SystemDriverDatabase dbModule) {
-                var dbModuleConfig = dbModule.getConfiguration();
-                dbModuleConfig.systemUIDs.addAll(systemUIDs);
-                dbModule.updateConfig(dbModuleConfig);
-            }
-        } catch (SensorHubException e) {
-            throw new RuntimeException(e);
-        }
-    }
+            // Collect database from configured module ID
+            IObsSystemDatabase obsDatabase = ((SystemDriverDatabase) getParentHub().getModuleRegistry().getModuleById(databaseId)).getWrappedDatabase();
 
-    private void removeSystemsFromDatabase(String databaseId, boolean deleteData, List<String> systemUIDs) {
-        try {
-            IObsSystemDatabase obsDatabase = null;
-            // Remove system ids from database config
-            if (getParentHub().getModuleRegistry().getModuleById(databaseId) instanceof SystemDriverDatabase dbModule) {
-                var dbModuleConfig = dbModule.getConfiguration();
-                for (String sysUID : systemUIDs)
-                    dbModuleConfig.systemUIDs.remove(sysUID);
-                dbModule.updateConfig(dbModuleConfig);
-                // Pass along retrieved IObsSystemDatabase to clean
-                obsDatabase = dbModule.getWrappedDatabase();
-            }
-
-            // Optionally delete the system data too
-            if (deleteData && obsDatabase != null) {
+            // Delete the system data
+            if (obsDatabase != null) {
                 var transactionHandler = new SystemDatabaseTransactionHandler(getParentHub().getEventBus(), obsDatabase);
                 // Don't use forEach bc nested try-catch
                 for (String sysUID : systemUIDs)
@@ -291,57 +240,8 @@ public class LaneSystem extends SensorSystem {
             }
         } catch (SensorHubException e) {
             throw new RuntimeException(e);
-        }
-    }
-
-    private void addSystemsToPurgePolicy(String databaseId, List<String> systemUIDs, int purgePeriodMinutes) {
-        // Add systems to purge policy
-        try {
-            if (getParentHub().getModuleRegistry().getModuleById(databaseId) instanceof SystemDriverDatabase dbModule) {
-                var dbModuleConfig = dbModule.getConfiguration();
-                // If first purge policy exists, use it and make sure the purge period matches the config
-                var purgePolicies = dbModuleConfig.autoPurgeConfig;
-                if (purgePolicies != null && !purgePolicies.isEmpty()) {
-                    // Check if first purge policy has correct purge period, and if it has other video drivers, then add it or skip it
-                    var firstPolicy = purgePolicies.get(0);
-                    if (firstPolicy.purgePeriod != purgePeriodMinutes * 60)
-                        firstPolicy.purgePeriod = purgePeriodMinutes * 60;
-                    // Remove asterisk just in case it's there
-                    firstPolicy.systemUIDs.remove("*");
-                    firstPolicy.systemUIDs.addAll(systemUIDs);
-                }
-                // If there's no purge policies, create a new one with the PP and MRA from config
-                else {
-                    var newPurgePolicy = new MaxAgeAutoPurgeConfig();
-                    newPurgePolicy.systemUIDs = new ArrayList<>(systemUIDs);
-                    newPurgePolicy.purgePeriod = purgePeriodMinutes * 60;
-                    newPurgePolicy.maxRecordAge = purgePeriodMinutes * 60;
-                    newPurgePolicy.enabled = true;
-                    if (purgePolicies == null)
-                        purgePolicies = new ArrayList<>();
-                    purgePolicies.add(newPurgePolicy);
-                }
-                dbModule.updateConfig(dbModuleConfig);
-            }
-        } catch (SensorHubException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    private void removeSystemsFromPurgePolicy(String databaseId, List<String> systemUIDs) {
-        // Remove systems in purge policy
-        try {
-            if (getParentHub().getModuleRegistry().getModuleById(databaseId) instanceof SystemDriverDatabase dbModule) {
-                var dbModuleConfig = dbModule.getConfiguration();
-                var purgePolicies = dbModuleConfig.autoPurgeConfig;
-                if (purgePolicies != null && !purgePolicies.isEmpty()) {
-                    for (var policy : purgePolicies)
-                        policy.systemUIDs.removeAll(systemUIDs);
-                    dbModule.updateConfig(dbModuleConfig);
-                }
-            }
-        } catch (SensorHubException e) {
-            throw new RuntimeException(e);
+        } catch (ClassCastException e) {
+            throw new ClassCastException("Database ID in configuration does not correspond to a System Driver Database!");
         }
     }
 
@@ -364,132 +264,11 @@ public class LaneSystem extends SensorSystem {
     }
 
     private void handleLaneEvent(Event e) {
-        // TODO: Add config listener to remove old system from database config if system uid is updated
-        // TODO: Add config listener to swap to new database if lane database is changed
         // TODO: Handle events for video drivers, RPM drivers, and process module
-        // TODO: Add listener to nullify rpm module and process module if they are removed
         // TODO: If lane is not saved to config, then delete database data and process?
-
-        if (e instanceof SystemAddedEvent event) {
-
-            // If process is the newly added system, attach  it to database
-            if (existingProcessModule != null && existingProcessModule.getCurrentDescription() != null && Objects.equals(event.getSystemUID(), existingProcessModule.getUniqueIdentifier()) && getLaneDatabaseID() != null) {
-                threadPool.execute(() -> {
-                    try {
-                        existingProcessModule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                        Async.waitForCondition(() -> checkDriverFinishedRegistration(existingProcessModule.getUniqueIdentifier(), existingProcessModule), 500, 10000);
-                        addSystemsToDatabase(getLaneDatabaseID(), List.of(existingProcessModule.getUniqueIdentifier()));
-                    } catch (TimeoutException | SensorHubException ex) {
-                        throw new RuntimeException(ex);
-                    }
-                });
-            }
-
-            // If lane is the newly added system, attach it to database
-            if (existingRPMModule != null && Objects.equals(event.getSystemUID(), getUniqueIdentifier()) && getLaneDatabaseID() != null) {
-                threadPool.execute(() -> {
-                    try {
-                        waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                        existingRPMModule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                        getLogger().info("Waiting for lane to finish registration");
-                        Async.waitForCondition(() -> checkDriverFinishedRegistration(existingRPMModule.getUniqueIdentifier(), existingRPMModule), 500, 10000);
-                        getLogger().info("Finished registration");
-                        addSystemsToDatabase(getLaneDatabaseID(), List.of(getUniqueIdentifier()));
-                    } catch (TimeoutException | SensorHubException ex) {
-                        throw new RuntimeException(ex);
-                    }
-                });
-            }
-
-            // Signifies that a subsystem was added to this lane
-            if (event.getParentGroupUID() != null && event.getParentGroupUID().equals(getUniqueIdentifier())) {
-                // If added subsystems are video systems, then add their UIDs to the database purge policy
-                if (getLaneDatabaseID() != null
-                        && getLaneDatabaseConfig() != null
-                        && getLaneDatabaseConfig().autoPurgeVideoData
-                        && getLaneDatabaseConfig().purgePeriodMinutes > 0) {
-
-                    // Find newly added system with this lane as parent
-                    var sysFilterBuilder = new SystemFilter.Builder()
-                            .withUniqueIDs(event.getSystemUID())
-                            .withParents(new SystemFilter.Builder().withUniqueIDs(getUniqueIdentifier()).build());
-
-                    // Generic video data stream filter
-                    var videoDsFilter = new DataStreamFilter.Builder().withObservedProperties(VideoCamHelper.DEF_IMAGE, VideoCamHelper.DEF_VIDEOFRAME).build();
-
-                    var videoSystems = getParentHub().getDatabaseRegistry().getFederatedDatabase().getSystemDescStore().select(sysFilterBuilder.withDataStreams(videoDsFilter).build()).toList();
-                    // If system has video datastreams
-                    if (!videoSystems.isEmpty()) {
-                        // Add to purge policy
-                        List<String> videoSystemUIDs = new ArrayList<>();
-                        videoSystems.forEach(videoSystem -> videoSystemUIDs.add(videoSystem.getUniqueIdentifier()));
-                        addSystemsToPurgePolicy(getLaneDatabaseID(), videoSystemUIDs, getLaneDatabaseConfig().purgePeriodMinutes);
-                    }
-                }
-
-                // Anytime a subsystem is added, we need to restart our associated process, so it can pick up on new systems
-                if (existingRPMModule != null && existingProcessModule != null && existingRPMModule.isStarted() && this.isStarted()
-                        && getParentHub().getSystemDriverRegistry().hasDatabase(this.getUniqueIdentifier())) {
-                    // TODO: Test that a restart changes the output structure for process
-                    threadPool.execute(() -> {
-                        boolean success = false;
-                        int retries = 0;
-                        while(!success && retries < 5 && !existingProcessModule.isStarted()) {
-                            // Re-init and start process module
-                            try {
-                                waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                                existingRPMModule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                                var dbModule = (SystemDriverDatabase) getParentHub().getModuleRegistry().getModuleById(getLaneDatabaseID());
-                                Async.waitForCondition(() -> dbModule.getConfiguration().systemUIDs.contains(getUniqueIdentifier()), 500, 10000);
-                                dbModule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-                                Async.waitForCondition(() -> checkDriverFinishedRegistration(existingRPMModule.getUniqueIdentifier(), existingRPMModule), 500, 10000);
-                                getParentHub().getModuleRegistry().initModule(existingProcessModule.getLocalID());
-                                existingProcessModule.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
-                                getParentHub().getModuleRegistry().startModule(existingProcessModule.getLocalID());
-                            } catch (SensorHubException | TimeoutException ex) {
-                                retries++;
-                                getLogger().warn("Process module initialization attempt {} failed, retrying...", retries, ex);
-                                try {
-                                    Thread.sleep(1000);
-                                } catch (InterruptedException ie) {
-                                    Thread.currentThread().interrupt();
-                                    break;
-                                }
-                            }
-                        }
-                    });
-                }
-            }
-        }
-
-        else if (e instanceof SystemRemovedEvent event) {
-
+        if (e instanceof SystemRemovedEvent event) {
             // Signifies that a subsystem was removed from the lane
             if (event.getParentGroupUID() != null && event.getParentGroupUID().equals(getUniqueIdentifier())) {
-                // If video subsystems are removed, then remove their UIDs from the database purge policy
-                if (getLaneDatabaseID() != null
-                && getLaneDatabaseConfig() != null
-                && getLaneDatabaseConfig().autoPurgeVideoData
-                && getLaneDatabaseConfig().purgePeriodMinutes > 0) {
-
-                    // TODO: Probably put this in its own method
-                    // Find removed system with this lane as parent
-                    var sysFilterBuilder = new SystemFilter.Builder()
-                            .withUniqueIDs(event.getSystemUID())
-                            .withParents(new SystemFilter.Builder().withUniqueIDs(getUniqueIdentifier()).build());
-
-                    // Generic video data stream filter
-                    var videoDsFilter = new DataStreamFilter.Builder().withObservedProperties(VideoCamHelper.DEF_IMAGE, VideoCamHelper.DEF_VIDEOFRAME).build();
-
-                    var videoSystems = getParentHub().getDatabaseRegistry().getFederatedDatabase().getSystemDescStore().select(sysFilterBuilder.withDataStreams(videoDsFilter).build()).toList();
-                    // If system has video datastreams
-                    if (!videoSystems.isEmpty()) {
-                        // Remove from purge policy
-                        List<String> videoSystemUIDs = new ArrayList<>();
-                        videoSystems.forEach(videoSystem -> videoSystemUIDs.add(videoSystem.getUniqueIdentifier()));
-                        removeSystemsFromPurgePolicy(getLaneDatabaseID(), videoSystemUIDs);
-                    }
-                }
 
                 // If RPM is removed, nullify local object
                 if (event.getSystemUID().contains(RAPISCAN_URI) || event.getSystemUID().contains(ASPECT_URI))
@@ -502,17 +281,16 @@ public class LaneSystem extends SensorSystem {
         }
 
         else if (e instanceof ModuleEvent event) {
-
             // Module STATE_CHANGED events
             if (event.getType() == ModuleEvent.Type.STATE_CHANGED) {
-
                 // Module STARTED events
                 if (event.getNewState() == ModuleEvent.ModuleState.STARTED) {
-
                     // If RPM module is started, then start process module
-                    if (existingRPMModule != null && Objects.equals(event.getSourceID(), existingRPMModule.getLocalID()) && existingProcessModule != null
-                    && !existingProcessModule.isStarted()) {
+                    if (existingRPMModule != null && Objects.equals(event.getSourceID(), existingRPMModule.getLocalID()) && existingProcessModule != null && !existingProcessModule.isStarted()) {
                         try {
+                            if (existingProcessModule.getCurrentState().equals(ModuleEvent.ModuleState.LOADED))
+                                getParentHub().getModuleRegistry().initModule(existingProcessModule.getLocalID());
+                            existingProcessModule.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
                             getParentHub().getModuleRegistry().startModuleAsync(existingProcessModule);
                         } catch (SensorHubException ex) {
                             throw new RuntimeException(ex);
@@ -522,8 +300,7 @@ public class LaneSystem extends SensorSystem {
                 }
 
                 // Module STOPPED events
-                if (event.getNewState() == ModuleEvent.ModuleState.STOPPED) {
-
+                else if (event.getNewState() == ModuleEvent.ModuleState.STOPPED) {
                     // If RPM module is stopped, then stop process module
                     if (existingRPMModule != null && Objects.equals(event.getSourceID(), existingRPMModule.getLocalID()) && existingProcessModule != null) {
                         try {
@@ -532,8 +309,16 @@ public class LaneSystem extends SensorSystem {
                             throw new RuntimeException(ex);
                         }
                     }
+                }
 
-
+                // New module loaded
+                else if (event.getNewState() == ModuleEvent.ModuleState.LOADED) {
+                    // If process is loaded manually and null locally, find it and keep track of it
+                    if (event.getModule() instanceof OccupancyProcessModule processModule && existingProcessModule == null) {
+                        if (Objects.equals(processModule.getConfiguration().systemUID, this.getUniqueIdentifier())) {
+                            existingProcessModule = processModule;
+                        }
+                    }
                 }
             }
         }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/CameraType.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/CameraType.java
@@ -1,0 +1,5 @@
+package com.botts.impl.system.lane.config;
+
+public enum CameraType {
+    AXIS, SONY
+}

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/FFMpegConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/FFMpegConfig.java
@@ -1,0 +1,36 @@
+package com.botts.impl.system.lane.config;
+
+import org.sensorhub.api.config.DisplayInfo;
+
+/**
+ * Configuration for FFMpeg driver (endpoints) based on camera manufacturer
+ * @author Kyle Fitzpatrick
+ * @since May 6, 2025
+ */
+public class FFMpegConfig {
+    @DisplayInfo.Required
+    @DisplayInfo(label = "FFmpeg Camera Type", desc = "FFmpeg Camera module to generate for this lane")
+    public CameraType ffmpegType;
+
+    @DisplayInfo.Required
+    @DisplayInfo(label = "FFmpeg Unique ID", desc = "FFmpeg UID for new submodule if RPM type is specified. Please do not include osh UID prefix (i.e. urn:osh:sensor:rapiscan)")
+    public String ffmpegUniqueId;
+
+    @DisplayInfo.Required
+    @DisplayInfo(label = "FFmpeg Label", desc = "Friendly name for FFmpeg module")
+    public String ffmpegLabel;
+
+    @DisplayInfo.Required
+    @DisplayInfo.FieldType(DisplayInfo.FieldType.Type.REMOTE_ADDRESS)
+    @DisplayInfo(label = "Remote Host")
+    public String remoteHost;
+
+    @DisplayInfo(label = "Username")
+    public String username;
+
+    @DisplayInfo.FieldType(DisplayInfo.FieldType.Type.PASSWORD)
+    @DisplayInfo(label = "Password")
+    public String password;
+
+    // Port, fps, full endpoint should be autofilled
+}

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/LaneDatabaseConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/LaneDatabaseConfig.java
@@ -32,10 +32,4 @@ LaneDatabaseConfig {
     @DisplayInfo.ModuleType(SystemDriverDatabase.class)
     public String laneDatabaseId;
 
-    @DisplayInfo(label = "Auto Purge Video Data", desc = "Select this to automatically add video systems to your lane database's purge policy")
-    public boolean autoPurgeVideoData = true;
-
-    @DisplayInfo(label = "Purge Period (in minutes)", desc = "Purges video data every x minutes")
-    public int purgePeriodMinutes = 5;
-
 }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/LaneOptionsConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/LaneOptionsConfig.java
@@ -17,6 +17,8 @@ package com.botts.impl.system.lane.config;
 
 import org.sensorhub.api.config.DisplayInfo;
 
+import java.util.List;
+
 /**
  * Additional configuration settings for the Lane Sensor System.
  *
@@ -33,5 +35,8 @@ public class LaneOptionsConfig {
 
     @DisplayInfo(label = "Initial RPM Config", desc = "Config used for initial RPM setup")
     public RPMConfig rpmConfig;
+
+    @DisplayInfo(label = "Initial Camera Config", desc = "Config used for initial FFmpeg camera setup")
+    public List<FFMpegConfig> ffmpegConfig;
 
 }

--- a/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
+++ b/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
@@ -255,9 +255,7 @@ public class LaneTests {
         laneConfig.name = "Lane " + id;
         var opts = laneConfig.laneOptionsConfig = new LaneOptionsConfig();
         var db = opts.laneDatabaseConfig = new LaneDatabaseConfig();
-        db.purgePeriodMinutes = 5;
         db.laneDatabaseId = LANE_DATABASE_ID;
-        db.autoPurgeVideoData = true;
         opts.createProcess = true;
         var rpm = opts.rpmConfig = new RPMConfig();
         rpm.rpmUniqueId = id;

--- a/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
+++ b/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
@@ -23,17 +23,26 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.sensorhub.api.ISensorHub;
 import org.sensorhub.api.common.SensorHubException;
+import org.sensorhub.api.event.Event;
 import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.impl.SensorHub;
 import org.sensorhub.impl.database.system.SystemDriverDatabase;
 import org.sensorhub.impl.database.system.SystemDriverDatabaseConfig;
 import org.sensorhub.impl.datastore.h2.MVObsSystemDatabaseConfig;
 import org.sensorhub.impl.processing.AbstractProcessModule;
+import org.sensorhub.impl.sensor.SensorSystemConfig;
+import org.sensorhub.impl.sensor.fakeweather.FakeWeatherConfig;
+import org.sensorhub.impl.sensor.fakeweather.FakeWeatherDescriptor;
+import org.sensorhub.impl.sensor.fakeweather.FakeWeatherSensor;
 import org.sensorhub.utils.Async;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.Flow;
 import java.util.concurrent.TimeoutException;
 
 import static org.junit.Assert.*;
@@ -57,36 +66,48 @@ public class LaneTests {
     // Used for tests
     private SensorHub hub;
     private LaneSystem lane;
+    private List<LaneSystem> multipleLanes;
     private SystemDriverDatabase database;
     private File dbFile;
 
+    // For specific process test
+    private Flow.Subscription processSub;
+    private int numOutputsBefore;
+
     @Before
     public void setUp() throws Exception {
-        if (dbFile == null) {
-            // Create temp file to use with System Driver Database
-            dbFile = File.createTempFile("testlanedb", ".dat");
-            dbFile.deleteOnExit();
+        // Create temp file to use with System Driver Database
+        dbFile = File.createTempFile("testlanedb", ".dat");
+        dbFile.deleteOnExit();
+
+        hub = new SensorHub();
+        hub.start();
+
+        database = loadSystemDriverDatabase(hub);
+        assertNotNull(database);
+        assertNull(database.getCurrentError());
+        assertEquals(database.getCurrentState(), ModuleEvent.ModuleState.STARTED);
+
+        lane = loadLaneModule(hub, "x");
+        assertNotNull(lane);
+        assertNull(lane.getCurrentError());
+        assertEquals(lane.getCurrentState(), ModuleEvent.ModuleState.LOADED);
+        startLaneAndWaitForStarted();
+        assertEquals(lane.getCurrentState(), ModuleEvent.ModuleState.STARTED);
+
+        multipleLanes = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            multipleLanes.add(loadLaneModule(hub, "" + i));
         }
 
-        if (hub == null) {
-            hub = new SensorHub();
-            hub.start();
+        for (LaneSystem lane : multipleLanes) {
+            hub.getModuleRegistry().initModule(lane.getLocalID());
+            lane.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
+            hub.getModuleRegistry().startModuleAsync(lane);
         }
 
-        if (database == null) {
-            database = loadSystemDriverDatabase(hub);
-            assertNotNull(database);
-            assertNull(database.getCurrentError());
-            assertEquals(database.getCurrentState(), ModuleEvent.ModuleState.STARTED);
-        }
-
-        if (lane == null) {
-            lane = loadLaneModule(hub);
-            assertNotNull(lane);
-            assertNull(lane.getCurrentError());
-            assertEquals(lane.getCurrentState(), ModuleEvent.ModuleState.LOADED);
-            startLaneAndWaitForStarted();
-            assertEquals(lane.getCurrentState(), ModuleEvent.ModuleState.STARTED);
+        for (LaneSystem lane : multipleLanes) {
+            lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
         }
     }
 
@@ -96,8 +117,18 @@ public class LaneTests {
     }
 
     @Test
-    public void testLaneAddedToDatabase() throws InterruptedException, TimeoutException {
-        Async.waitForCondition(() -> database.getConfiguration().systemUIDs.contains(lane.getUniqueIdentifier()), 500, 10000);
+    public void testMultipleLanesCreateRPMModules() throws SensorHubException {
+        boolean failed = false;
+        for (LaneSystem lane : multipleLanes) {
+            lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        }
+
+        for (LaneSystem lane : multipleLanes) {
+            if (lane.getMembers().isEmpty())
+                failed = true;
+            break;
+        }
+        assertFalse(failed);
     }
 
     @Test
@@ -107,9 +138,104 @@ public class LaneTests {
         System.out.println("Process started");
     }
 
+    @Test
+    public void testAllProcessesStarted() throws TimeoutException {
+        List<OccupancyProcessModule> processModules = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class).stream().toList();
+        System.out.println(processModules.size());
+        for (OccupancyProcessModule processModule : processModules) {
+            Async.waitForCondition(() -> processModule.getCurrentState() == ModuleEvent.ModuleState.STARTED, 500, 20000);
+            System.out.println("Process " + processModule.getName() + " started");
+        }
+        System.out.println("All processes started");
+    }
+
+    @Test
+    public void testAllProcessesCreated() throws SensorHubException {
+        var processModules = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class);
+        var lanes = hub.getModuleRegistry().getLoadedModules(LaneSystem.class);
+        System.out.println("Processes: " + processModules.size());
+        System.out.println("Lanes: " + lanes.size());
+        assertEquals(processModules.size(), lanes.size());
+    }
+
+    @Test
+    public void testProcessContainsNewOutputs() throws TimeoutException, SensorHubException {
+        // TODO: Add test
+        // Check lane is started
+        lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        var processes = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class).stream().toList();
+        OccupancyProcessModule process = processes.stream().filter(p -> p.getConfiguration().systemUID.equals(lane.getUniqueIdentifier())).findFirst().orElse(null);
+        assertNotNull(process);
+        // Check process is started
+        process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        // Track number of outputs of only one lane submodule (should be ~10)
+        numOutputsBefore = process.getOutputs().size();
+        // Add submodule to lane
+        var weatherSubmodule = lane.addSubsystem(createWeatherSubmodule(hub, "1"));
+        System.out.println("Weather submodule loaded");
+        System.out.println(weatherSubmodule.getCurrentState());
+        // Wait for autostart to kick in
+        weatherSubmodule.init();
+        weatherSubmodule.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
+        weatherSubmodule.start();
+        var weatherStarted = weatherSubmodule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        assertTrue(weatherStarted);
+        System.out.println("Weather submodule started");
+        System.out.println(weatherSubmodule.getCurrentState());
+        // Check process adds submodule's outputs
+        System.out.println("Num outputs before: " + numOutputsBefore);
+        System.out.println("Num outputs after: " + process.getOutputs().size());
+        Async.waitForCondition(() -> numOutputsBefore != process.getOutputs().size(), 20000);
+        // Check process is started with new outputs
+        System.out.println("Num outputs before: " + numOutputsBefore);
+        System.out.println("Num outputs after: " + process.getOutputs().size());
+        System.out.println(process.getCurrentState());
+        boolean isStarted = process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        System.out.println("Process: " + process.getCurrentState());
+        assertTrue(isStarted);
+    }
+
+    @Test
+    public void testProcessStopsAndStartsWithLane() throws SensorHubException {
+        var processes = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class).stream().toList();
+        OccupancyProcessModule process = processes.stream().filter(p -> p.getConfiguration().systemUID.equals(lane.getUniqueIdentifier())).findFirst().orElse(null);
+        // Check lane is started
+        lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        // Check process is started
+        process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+        // Add listener to process module
+        new Thread(() -> {
+            try {
+                Async.waitForCondition(() -> process.getCurrentState() == ModuleEvent.ModuleState.STARTING, 500, 20000);
+                System.out.println("Process has been restarted..");
+                System.out.println(process.getCurrentState());
+            } catch (TimeoutException e) {
+                fail();
+                throw new RuntimeException(e);
+            }
+        }).start();
+        // Stop lane
+        lane.stop();
+        lane.waitForState(ModuleEvent.ModuleState.STOPPED, 5000);
+        // Start lane
+        lane.start();
+        lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+    }
+
     private void startLaneAndWaitForStarted() throws SensorHubException {
         hub.getModuleRegistry().startModule(lane.getLocalID());
         lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+    }
+
+    private SensorSystemConfig.SystemMember createWeatherSubmodule(ISensorHub hub, String id) throws SensorHubException {
+        FakeWeatherConfig config = (FakeWeatherConfig) hub.getModuleRegistry().createModuleConfig(hub.getModuleRegistry().getInstalledModuleTypes(FakeWeatherSensor.class).stream().toList().get(0));
+        assertNotNull(config);
+        config.autoStart = true;
+        config.name = "Weather Driver " + id;
+        config.serialNumber = id;
+        var newMember = new SensorSystemConfig.SystemMember();
+        newMember.config = config;
+        return newMember;
     }
 
     private SystemDriverDatabase loadSystemDriverDatabase(ISensorHub hub) throws SensorHubException {
@@ -118,17 +244,18 @@ public class LaneTests {
         dbModuleConfig.name = "Lane DB";
         dbModuleConfig.autoStart = true;
         dbModuleConfig.databaseNum = 1;
+        dbModuleConfig.systemUIDs = new HashSet<>(List.of("urn:osh:system:lane:*", "urn:osh:process:occupancy:*"));
         MVObsSystemDatabaseConfig dbConfig = (MVObsSystemDatabaseConfig) (dbModuleConfig.dbConfig = new MVObsSystemDatabaseConfig());
         dbConfig.storagePath = dbFile.getAbsolutePath();
         dbConfig.readOnly = false;
         return (SystemDriverDatabase) hub.getModuleRegistry().loadModule(dbModuleConfig);
     }
 
-    private LaneSystem loadLaneModule(ISensorHub hub) throws SensorHubException {
+    private LaneSystem loadLaneModule(ISensorHub hub, String id) throws SensorHubException {
         // This is what you should configure in the Admin UI
         LaneConfig laneConfig = (LaneConfig) hub.getModuleRegistry().createModuleConfig(new Descriptor());
-        laneConfig.uniqueID = LANE_UID;
-        laneConfig.name = LANE_NAME;
+        laneConfig.uniqueID = id;
+        laneConfig.name = "Lane " + id;
         var opts = laneConfig.laneOptionsConfig = new LaneOptionsConfig();
         var db = opts.laneDatabaseConfig = new LaneDatabaseConfig();
         db.purgePeriodMinutes = 5;
@@ -136,8 +263,8 @@ public class LaneTests {
         db.autoPurgeVideoData = true;
         opts.createProcess = true;
         var rpm = opts.rpmConfig = new RPMConfig();
-        rpm.rpmUniqueId = RPM_UID;
-        rpm.rpmLabel = RPM_NAME;
+        rpm.rpmUniqueId = id;
+        rpm.rpmLabel = "RPM " + id;
         rpm.rpmType = RPMType.RAPISCAN;
         rpm.remoteHost = RAPISCAN_HOST;
         rpm.remotePort = RAPISCAN_PORT;

--- a/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
+++ b/sensors/sensorhub-system-lane/src/test/java/LaneTests.java
@@ -23,17 +23,14 @@ import org.junit.Test;
 import org.junit.runners.MethodSorters;
 import org.sensorhub.api.ISensorHub;
 import org.sensorhub.api.common.SensorHubException;
-import org.sensorhub.api.event.Event;
 import org.sensorhub.api.module.ModuleEvent;
 import org.sensorhub.impl.SensorHub;
 import org.sensorhub.impl.database.system.SystemDriverDatabase;
 import org.sensorhub.impl.database.system.SystemDriverDatabaseConfig;
 import org.sensorhub.impl.datastore.h2.MVObsSystemDatabaseConfig;
 import org.sensorhub.impl.processing.AbstractProcessModule;
-import org.sensorhub.impl.sensor.SensorSystemConfig;
-import org.sensorhub.impl.sensor.fakeweather.FakeWeatherConfig;
-import org.sensorhub.impl.sensor.fakeweather.FakeWeatherDescriptor;
-import org.sensorhub.impl.sensor.fakeweather.FakeWeatherSensor;
+//import org.sensorhub.impl.sensor.fakeweather.FakeWeatherConfig;
+//import org.sensorhub.impl.sensor.fakeweather.FakeWeatherSensor;
 import org.sensorhub.utils.Async;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -158,42 +155,42 @@ public class LaneTests {
         assertEquals(processModules.size(), lanes.size());
     }
 
-    @Test
-    public void testProcessContainsNewOutputs() throws TimeoutException, SensorHubException {
-        // TODO: Add test
-        // Check lane is started
-        lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-        var processes = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class).stream().toList();
-        OccupancyProcessModule process = processes.stream().filter(p -> p.getConfiguration().systemUID.equals(lane.getUniqueIdentifier())).findFirst().orElse(null);
-        assertNotNull(process);
-        // Check process is started
-        process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-        // Track number of outputs of only one lane submodule (should be ~10)
-        numOutputsBefore = process.getOutputs().size();
-        // Add submodule to lane
-        var weatherSubmodule = lane.addSubsystem(createWeatherSubmodule(hub, "1"));
-        System.out.println("Weather submodule loaded");
-        System.out.println(weatherSubmodule.getCurrentState());
-        // Wait for autostart to kick in
-        weatherSubmodule.init();
-        weatherSubmodule.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
-        weatherSubmodule.start();
-        var weatherStarted = weatherSubmodule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-        assertTrue(weatherStarted);
-        System.out.println("Weather submodule started");
-        System.out.println(weatherSubmodule.getCurrentState());
-        // Check process adds submodule's outputs
-        System.out.println("Num outputs before: " + numOutputsBefore);
-        System.out.println("Num outputs after: " + process.getOutputs().size());
-        Async.waitForCondition(() -> numOutputsBefore != process.getOutputs().size(), 20000);
-        // Check process is started with new outputs
-        System.out.println("Num outputs before: " + numOutputsBefore);
-        System.out.println("Num outputs after: " + process.getOutputs().size());
-        System.out.println(process.getCurrentState());
-        boolean isStarted = process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
-        System.out.println("Process: " + process.getCurrentState());
-        assertTrue(isStarted);
-    }
+    // NOTE: Uncomment all related simulated weather driver code if you want to run this test, or perform test with different module
+//    @Test
+//    public void testProcessContainsNewOutputs() throws TimeoutException, SensorHubException {
+//        // Check lane is started
+//        lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+//        var processes = hub.getModuleRegistry().getLoadedModules(OccupancyProcessModule.class).stream().toList();
+//        OccupancyProcessModule process = processes.stream().filter(p -> p.getConfiguration().systemUID.equals(lane.getUniqueIdentifier())).findFirst().orElse(null);
+//        assertNotNull(process);
+//        // Check process is started
+//        process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+//        // Track number of outputs of only one lane submodule (should be ~10)
+//        numOutputsBefore = process.getOutputs().size();
+//        // Add submodule to lane
+//        var weatherSubmodule = lane.addSubsystem(createWeatherSubmodule(hub, "1"));
+//        System.out.println("Weather submodule loaded");
+//        System.out.println(weatherSubmodule.getCurrentState());
+//        // Wait for autostart to kick in
+//        weatherSubmodule.init();
+//        weatherSubmodule.waitForState(ModuleEvent.ModuleState.INITIALIZED, 10000);
+//        weatherSubmodule.start();
+//        var weatherStarted = weatherSubmodule.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+//        assertTrue(weatherStarted);
+//        System.out.println("Weather submodule started");
+//        System.out.println(weatherSubmodule.getCurrentState());
+//        // Check process adds submodule's outputs
+//        System.out.println("Num outputs before: " + numOutputsBefore);
+//        System.out.println("Num outputs after: " + process.getOutputs().size());
+//        Async.waitForCondition(() -> numOutputsBefore != process.getOutputs().size(), 20000);
+//        // Check process is started with new outputs
+//        System.out.println("Num outputs before: " + numOutputsBefore);
+//        System.out.println("Num outputs after: " + process.getOutputs().size());
+//        System.out.println(process.getCurrentState());
+//        boolean isStarted = process.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
+//        System.out.println("Process: " + process.getCurrentState());
+//        assertTrue(isStarted);
+//    }
 
     @Test
     public void testProcessStopsAndStartsWithLane() throws SensorHubException {
@@ -227,16 +224,16 @@ public class LaneTests {
         lane.waitForState(ModuleEvent.ModuleState.STARTED, 10000);
     }
 
-    private SensorSystemConfig.SystemMember createWeatherSubmodule(ISensorHub hub, String id) throws SensorHubException {
-        FakeWeatherConfig config = (FakeWeatherConfig) hub.getModuleRegistry().createModuleConfig(hub.getModuleRegistry().getInstalledModuleTypes(FakeWeatherSensor.class).stream().toList().get(0));
-        assertNotNull(config);
-        config.autoStart = true;
-        config.name = "Weather Driver " + id;
-        config.serialNumber = id;
-        var newMember = new SensorSystemConfig.SystemMember();
-        newMember.config = config;
-        return newMember;
-    }
+//    private SensorSystemConfig.SystemMember createWeatherSubmodule(ISensorHub hub, String id) throws SensorHubException {
+//        FakeWeatherConfig config = (FakeWeatherConfig) hub.getModuleRegistry().createModuleConfig(hub.getModuleRegistry().getInstalledModuleTypes(FakeWeatherSensor.class).stream().toList().get(0));
+//        assertNotNull(config);
+//        config.autoStart = true;
+//        config.name = "Weather Driver " + id;
+//        config.serialNumber = id;
+//        var newMember = new SensorSystemConfig.SystemMember();
+//        newMember.config = config;
+//        return newMember;
+//    }
 
     private SystemDriverDatabase loadSystemDriverDatabase(ISensorHub hub) throws SensorHubException {
         SystemDriverDatabaseConfig dbModuleConfig = new SystemDriverDatabaseConfig();


### PR DESCRIPTION
FFmpeg camera autofill based on provided axis and sony endpoints. Essentially satisfies the requested "specialized drivers for all cameras".

Haven't received additional information from Tyrone, so I made the following assumptions:

Axis:
rtsp://{username}:{password}@{remote host}/axis-media/media.amp?adjustablelivestream=1&resolution=640x480
Assuming http streaming, h264 codec, 24 fps

Sony:
rtsp://{username}:{password}@{remote host}:554/media/video1
Assuming rtsp streaming on port 554, h264 codec, 24 fps