### PR TITLE
Add custom stream path config for ffmpeg lane config

### DIFF
--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
@@ -411,14 +411,22 @@ public class LaneSystem extends SensorSystem {
         switch(ffmpegConfig.ffmpegType) {
             // Autofill with AXIS info
             case AXIS -> {
-                endpoint.append("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480"); // rtsp fps uncapped, might need to change
+                String path = "/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=h264"; // rtsp fps uncapped, might need to change
+                endpoint.append(path);
+                ffmpegConfig.streamPath = path; // Set path in the user-facing config to help indicate what's being autofilled
                 config.connection.fps = 24;
             }
             // Autofill with SONY info
             case SONY -> {
-                endpoint.append(":554/media/video1");
+                String path = ":554/media/video1";
+                endpoint.append(path);
+                ffmpegConfig.streamPath = path; // Set path in the user-facing config to help indicate what's being autofilled
                 config.connection.fps = 24; // Setting it to 24 for now, may change it later
 
+            }
+            case CUSTOM -> {
+                endpoint.append(ffmpegConfig.streamPath);
+                config.connection.fps = 24;
             }
             default -> { return null; }
         }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/CameraType.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/CameraType.java
@@ -1,5 +1,5 @@
 package com.botts.impl.system.lane.config;
 
 public enum CameraType {
-    AXIS, SONY
+    AXIS, SONY, CUSTOM
 }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/FFMpegConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/FFMpegConfig.java
@@ -32,5 +32,14 @@ public class FFMpegConfig {
     @DisplayInfo(label = "Password")
     public String password;
 
+    @DisplayInfo(label = "Stream Path", desc = "Path for video stream. Only applies for the CUSTOM camera type.")
+    public String streamPath;
+
+    public FFMpegConfig () {
+        ffmpegType = CameraType.AXIS;
+        streamPath = "/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=h264";
+    }
+
+
     // Port, fps, full endpoint should be autofilled
 }


### PR DESCRIPTION
Added the CUSTOM camera type. Takes a custom path from the lane system config and adds it to the ffmpeg driver.