### PR TITLE
Add codec choice for Axis cameras

### DIFF
--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/LaneSystem.java
@@ -516,9 +516,9 @@ public class LaneSystem extends SensorSystem {
         String path = defaultAxis;
 
         if(ffmpegConfig instanceof AxisCameraConfig axisVideoConfig){
-             path = axisVideoConfig.streamPath;
+             path = axisVideoConfig.streamPath.getPath();
         }else if (ffmpegConfig instanceof SonyCameraConfig sonyVideoConfig){
-             path = sonyVideoConfig.streamPath;
+             path = SonyCameraConfig.streamPath;
         }else if(ffmpegConfig instanceof CustomCameraConfig customVideoConfig){
              path = customVideoConfig.streamPath.length() > 0 ? customVideoConfig.streamPath : defaultAxis;
         }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/AxisCameraConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/AxisCameraConfig.java
@@ -9,7 +9,22 @@ import org.sensorhub.api.config.DisplayInfo;
  */
 public class AxisCameraConfig extends FFMpegConfig{
 
-    @DisplayInfo(label = "Stream Path", desc = "Path for video stream. Only applies for the CUSTOM camera type.")
-    public String streamPath = "/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=h264&videokeyframeinterval=15";
+    public enum CodecEndpoint {
+        H264("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=h264&videokeyframeinterval=15"),
+        MJPEG("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=jpeg&videokeyframeinterval=15");
+
+        private final String path;
+
+        public String getPath() {
+            return this.path;
+        }
+
+        CodecEndpoint(String path) {
+            this.path = path;
+        }
+    }
+
+    @DisplayInfo(label = "Stream Codec", desc = "Generate streaming URL with the selected codec.")
+    public CodecEndpoint streamPath = CodecEndpoint.H264;
 
 }

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/AxisCameraConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/AxisCameraConfig.java
@@ -11,7 +11,7 @@ public class AxisCameraConfig extends FFMpegConfig{
 
     public enum CodecEndpoint {
         H264("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=h264&videokeyframeinterval=15"),
-        MJPEG("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=jpeg&videokeyframeinterval=15");
+        MJPEG("/axis-media/media.amp?adjustablelivestream=1&resolution=640x480&videocodec=jpeg");
 
         private final String path;
 

--- a/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/SonyCameraConfig.java
+++ b/sensors/sensorhub-system-lane/src/main/java/com/botts/impl/system/lane/config/SonyCameraConfig.java
@@ -9,7 +9,6 @@ import org.sensorhub.api.config.DisplayInfo;
  */
 public class SonyCameraConfig extends FFMpegConfig{
 
-    @DisplayInfo(label = "Stream Path", desc = "Path for video stream. Only applies for the CUSTOM camera type.")
-    public String streamPath = ":554/media/video1";
+    public static final String streamPath = ":554/media/video1";
 
 }


### PR DESCRIPTION
Added mjpeg/h264 selection for axis cameras. Removed path option for Sony cameras (H264 with path /media/video1).