### PR TITLE
Remove lock from RPM reconnect heartbeat

### DIFF
--- a/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/AspectSensor.java
+++ b/sensors/sensorhub-driver-aspect/src/main/java/com/botts/impl/sensor/aspect/AspectSensor.java
@@ -56,7 +56,7 @@ public class AspectSensor extends AbstractSensorModule<AspectConfig> {
     RobustConnection connection;
     private boolean isRunning;
     private Thread tcpConnectionThread;
-    private static final Object heartbeatLock = new Object();
+    //private static final Object heartbeatLock = new Object();
 
     @Override
     public void doInit() throws SensorHubException {
@@ -291,24 +291,22 @@ public class AspectSensor extends AbstractSensorModule<AspectConfig> {
 
 
     public void heartbeat() {
-        synchronized (heartbeatLock) {
-            while (isRunning) {
-                if(messageHandler.getTimeSinceLastMessage() < config.commSettings.connection.reconnectPeriod) {
 
-                    this.connectionStatusOutput.onNewMessage(true);
-                }
-                else {
-                    this.connectionStatusOutput.onNewMessage(false);
+        while (isRunning) {
+            if(messageHandler.getTimeSinceLastMessage() < config.commSettings.connection.reconnectPeriod) {
 
-                    checkConnection();
-                }
-                try {
-                    Thread.sleep(1000);
-                } catch (Exception e) {
-                    logger.debug("Couldn't sleep");
-                }
+                this.connectionStatusOutput.onNewMessage(true);
+            }
+            else {
+                this.connectionStatusOutput.onNewMessage(false);
+
+                checkConnection();
+            }
+            try {
+                Thread.sleep(1000);
+            } catch (Exception e) {
+                logger.debug("Couldn't sleep");
             }
         }
     }
-
 }


### PR DESCRIPTION
Previously, only one aspect/rapiscan rpm would be able to reconnect if connection was lost. Removing the synchronized block in the heartbeat method should allow all to reconnect. Should also fix the issue of most rpms not having connection status outputs.