### PR TITLE
Additional error logging

### DIFF
--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
@@ -7,6 +7,7 @@ import java.util.function.Consumer;
 import org.sensorhub.api.common.SensorHubException;
 import org.sensorhub.api.event.Event;
 import org.sensorhub.api.event.IEventListener;
+import org.sensorhub.api.sensor.SensorException;
 import org.sensorhub.impl.sensor.AbstractSensorModule;
 import org.sensorhub.impl.sensor.DefaultLocationOutput;
 import org.sensorhub.impl.sensor.DefaultLocationOutputLLA;
@@ -160,13 +161,18 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
      * Create and initialize the video output. The caller has to be careful not to call this if the video output has
      * already been created and added to the sensor.
      */
-    protected void createVideoOutput(int[] videoDims, String codecFormat) {
+    protected void createVideoOutput(int[] videoDims, String codecFormat) throws SensorHubException {
     	videoOutput = new Video<FFMPEGconfigType>(this, videoDims, codecFormat);
     	if (executor != null) {
     		videoOutput.setExecutor(executor);
     	}
         addOutput(videoOutput, false);
-        videoOutput.init();
+        try {
+            videoOutput.init();
+        } catch (SensorException e) {
+            logger.error("Could not initialize video stream.", e);
+            throw new SensorHubException("Video stream misconfigured. Please ensure the camera's video stream is working before reinitializing.");
+        }
     }
 
     /**

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/Video.java
@@ -16,6 +16,7 @@ package org.sensorhub.impl.sensor.ffmpeg.outputs;
 import java.util.concurrent.Executor;
 
 import org.sensorhub.api.data.DataEvent;
+import org.sensorhub.api.sensor.SensorException;
 import org.sensorhub.impl.sensor.AbstractSensorOutput;
 import org.sensorhub.impl.sensor.ffmpeg.FFMPEGSensorBase;
 import org.sensorhub.impl.sensor.ffmpeg.common.SyncTime;
@@ -86,7 +87,7 @@ public class Video<FFMPEGConfigType extends FFMPEGConfig> extends AbstractSensor
      * Initializes the data structure for the output, defining the fields, their ordering,
      * and data types.
      */
-    public void init() {
+    public void init() throws SensorException {
 
         logger.debug("Initializing Video");
 
@@ -97,10 +98,18 @@ public class Video<FFMPEGConfigType extends FFMPEGConfig> extends AbstractSensor
         DataStream outputDef;
 
         logger.debug(codecFormat);
-        if (codecFormat.equals("mjpeg")){
-             outputDef = sweFactory.newVideoOutputMJPEG(getName(), videoFrameWidth, videoFrameHeight);
+
+        if (videoFrameHeight <= 0) {
+            throw new SensorException("videoFrameHeight (" + videoFrameHeight + ") must be greater than 0");
+        }
+        if (videoFrameWidth <= 0) {
+            throw new SensorException("videoFrameWidth (" + videoFrameWidth + ") must be greater than 0");
+        }
+
+        if (codecFormat.equals("mjpeg")) {
+            outputDef = sweFactory.newVideoOutputMJPEG(getName(), videoFrameWidth, videoFrameHeight);
         } else {
-             outputDef = sweFactory.newVideoOutputH264(getName(), videoFrameWidth, videoFrameHeight);
+            outputDef = sweFactory.newVideoOutputH264(getName(), videoFrameWidth, videoFrameHeight);
         }
 
 


### PR DESCRIPTION
Adds additional error logging. If a stream is detected but misconfigured or stopped, the width/height will be 0. Changed to throw a new exception that suggests the error is with the video stream source and not the ffmpeg driver.