### PR TITLE
Implement Persistent, Auto-Renewing Local CA PKI

### DIFF
--- a/services/sensorhub-service-bucket/src/main/java/com/botts/impl/service/bucket/Activator.java
+++ b/services/sensorhub-service-bucket/src/main/java/com/botts/impl/service/bucket/Activator.java
@@ -13,7 +13,7 @@
 
  ******************************************************************************/
 
-package com.botts.impl.service.oscar;
+package com.botts.impl.service.bucket;
 
 import org.osgi.framework.BundleActivator;
 import org.sensorhub.utils.OshBundleActivator;


### PR DESCRIPTION
This PR transitions the system from an ephemeral Root CA (where the private key was destroyed after leaf generation) to a Persistent Local CA architecture. 

Key changes include:
1.  **Refactored Utility:** `EphemeralCAUtility.java` is now `LocalCAUtility.java`.
2.  **Persistence:** The Root CA private key is now securely stored in `osh-keystore.p12` under the alias `root-ca`. It is encrypted using the auto-generated password in `.app_secrets`.
3.  **Automated Renewal:** `SensorHubWrapper` now calls `LocalCAUtility.checkAndRenewCertificates()` on every boot. If the `jetty` leaf certificate is within 30 days of expiration, it is automatically regenerated and signed by the persistent Root CA.
4.  **Lifespan Changes:** Root CA now has a 20-year lifespan to minimize manual trust-store updates for operators. Leaf certificates remain at 1 year.
5.  **Centralized Management:** Launch scripts no longer manually call the CA utility; all certificate lifecycle management is now handled within the Java application's startup sequence.
6.  **Documentation:** Architecture wikis have been updated to reflect the new persistent PKI and automated renewal logic as per AI_CONTRIBUTING_RULES.md.

Verification:
- Added `LocalCAUtilityTest.java` to verify initial generation and lifespan logic.
- Verified compilation and test pass via `./gradlew :security-utils:test`.
- Manual inspection of `launch.sh` and `launch.bat` confirm removal of obsolete generation steps.

Fixes #63

---
*PR created automatically by Jules for task [8825928146862250262](https://jules.google.com/task/8825928146862250262) started by @tyronechrisharris*

---
### 🔄 Auto-Distributed via Sync
**Original Flat Repo PR:** https://github.com/tyronechrisharris/oscar-flat/pull/64

### 🔗 Related Updates in this Sync:
- https://github.com/earocorn/osh-core/pull/9
- https://github.com/opensensorhub/osh-addons/pull/183
- https://github.com/Botts-Innovative-Research/oscar-viewer/pull/268
- https://github.com/Botts-Innovative-Research/osh-oakridge-modules/pull/168
- https://github.com/Botts-Innovative-Research/osh-oakridge-buildnode/pull/132
