### PR TITLE
Add per-lane statistics breakdown to siteStatistics output

### DIFF
--- a/sensors/sensorhub-system-lane/src/main/resources/com/botts/impl/system/lane/config/README.md
+++ b/sensors/sensorhub-system-lane/src/main/resources/com/botts/impl/system/lane/config/README.md
@@ -5,7 +5,7 @@ Specialized sensor system module to be used to create a lane with an RPM and vid
 ## Configuration
 
 Configuring the sensor requires:
-Select ```Sensors``` from the left-hand accordion control and right-click for the context-sensitive menu in the
+Select `Sensors` from the left-hand accordion control and right-click for the context-sensitive menu in the
 accordion control.
 Click 'Add New Module' and select 'Lane System' from the list of available modules.
 
@@ -14,7 +14,6 @@ Click 'Add New Module' and select 'Lane System' from the list of available modul
   - UniqueID: The platform's serial number, or a unique identifier, this will be used for all submodules and must be unique.
   - Auto Start: Check the box to start this module when OSH node is launched
   - Delete Data on Lane Removal: Check the box to remove systems data from database if lane is deleted from node.
-
 
 **- Fixed Location:**
   - Latitude:
@@ -30,13 +29,14 @@ Click 'Add New Module' and select 'Lane System' from the list of available modul
       - **Aspect RPM (Specific)**
         - Address Range:
 
-    - *Initial Camera Config:*
+  - *Initial Camera Config:*
     - Click `Add` and select between the `Axis`, `Sony` and the `Custom` video cameras. To configure the video cameras you need the host IP of the device. If applicable, you can add the username and password of the camera. Additional configurations may be necessary for different camera types. 
+    
       - **Sony/Axis/Custom**
-        - Remote Host:
-        - Username:
-        - Password:
+        - Remote Host: Enter your camera's `ip.ip.ip.ip:port` (e.g., `192.168.8.77:8554`).
+        - Username: Enter your camera's username in this field.
+        - Password: Enter your camera's password in this field.
       - **Axis (Specific):**
         - Stream Codec:
       - **Custom (Specific):**
-        - Stream Path:
+        - Stream Path: Enter everything that comes after your camera's `ip.ip.ip.ip:port` (e.g., `/lane04_cam`).

--- a/sensors/sensorhub-utils-rad/src/main/java/org/sensorhub/impl/utils/rad/RADHelper.java
+++ b/sensors/sensorhub-utils-rad/src/main/java/org/sensorhub/impl/utils/rad/RADHelper.java
@@ -1191,22 +1191,31 @@ public class RADHelper extends GeoPosHelper {
                 .description("Statistics for this node's RPMs/lanes")
                 .addField("samplingTime", createTime()
                         .asSamplingTimeIsoUTC())
-                .addField("allTime", createRecord()
-                        .label("All Time Total")
-                        .definition(getRadUri("AllTimeCount"))
-                        .addAllFields(createCountStatistics()))
-                .addField("monthly", createRecord()
-                        .label("Monthly Total")
-                        .definition(getRadUri("MonthlyCount"))
-                        .addAllFields(createCountStatistics()))
-                .addField("weekly", createRecord()
-                        .label("Weekly Total")
-                        .definition(getRadUri("WeeklyCount"))
-                        .addAllFields(createCountStatistics()))
-                .addField("daily", createRecord()
-                        .label("Daily Total")
-                        .definition(getRadUri("DailyCount"))
-                        .addAllFields(createCountStatistics()))
+                .addField("allTime", createBucketStatistics("All Time Total", "AllTimeCount"))
+                .addField("monthly", createBucketStatistics("Monthly Total", "MonthlyCount"))
+                .addField("weekly", createBucketStatistics("Weekly Total", "WeeklyCount"))
+                .addField("daily", createBucketStatistics("Daily Total", "DailyCount"))
+                .build();
+    }
+
+    /**
+     * Returns the per-bucket record (counts + per-lane breakdown) used inside
+     * {@link #createSiteStatistics()} and as the result schema of the
+     * Statistics control's custom-range command.
+     */
+    public DataRecord createBucketStatistics(String label, String definitionSuffix) {
+        return createRecord()
+                .label(label)
+                .definition(getRadUri(definitionSuffix))
+                .addAllFields(createCountStatistics())
+                .addField("numLanes", createCount()
+                        .id("numLanes")
+                        .label("Number of Lanes")
+                        .definition(getRadUri("NumberOfLanes")))
+                .addField("byLane", createArray()
+                        .withVariableSize("numLanes")
+                        .definition(getRadUri("LaneStatistics"))
+                        .withElement("lane", createLaneCountStatistics()))
                 .build();
     }
 
@@ -1248,6 +1257,32 @@ public class RADHelper extends GeoPosHelper {
                         .dataType(DataType.LONG)
                         .label("Total Number of Tampers")
                         .definition(getRadUri("NumTampers")))
+                .build();
+    }
+
+    /**
+     * Returns a per-lane record: lane UID, the eight standard count fields,
+     * and adjudication metrics. Used as the element type of the {@code byLane}
+     * array inside {@link #createBucketStatistics(String, String)}.
+     */
+    public DataRecord createLaneCountStatistics() {
+        return createRecord()
+                .name("laneCounts")
+                .label("Lane Counts")
+                .definition(getRadUri("LaneStatistics"))
+                .addField("laneId", createText()
+                        .label("Lane Unique ID")
+                        .definition(getRadUri("LaneID")))
+                .addAllFields(createCountStatistics())
+                .addField("numAdjudicated", createQuantity()
+                        .dataType(DataType.LONG)
+                        .label("Number of Adjudicated Occupancies")
+                        .definition(getRadUri("NumAdjudicated")))
+                .addField("avgTimeToAdjudicateSec", createQuantity()
+                        .dataType(DataType.DOUBLE)
+                        .label("Average Time to Adjudicate")
+                        .definition(getRadUri("AvgTimeToAdjudicate"))
+                        .uomCode("s"))
                 .build();
     }
 

--- a/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/OSCARServiceModule.java
+++ b/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/OSCARServiceModule.java
@@ -115,7 +115,7 @@ public class OSCARServiceModule extends AbstractModule<OSCARServiceConfig> imple
         if (database == null)
             database = getParentHub().getDatabaseRegistry().getFederatedDatabase();
 
-        statsOutput = new StatisticsOutput(system, database, config.statsFrequencyMinutes);
+        statsOutput = new StatisticsOutput(system, database, getParentHub().getIdEncoders().getObsIdEncoder(), config.statsFrequencyMinutes);
         system.addOutput(statsOutput, false);
     }
 

--- a/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/Statistics.java
+++ b/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/Statistics.java
@@ -1,5 +1,10 @@
 package com.botts.impl.service.oscar.stats;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
 public class Statistics {
     // Occupancies
     private long numOccupancies = 0;
@@ -11,6 +16,8 @@ public class Statistics {
     private long numGammaFaults = 0;
     private long numNeutronFaults = 0;
     private long numTampers = 0;
+    // Per-lane breakdown (empty when running on a node with no registered lanes)
+    private List<LaneStatistics> perLane = new ArrayList<>();
 
     public long getNumOccupancies() {
         return numOccupancies;
@@ -42,6 +49,10 @@ public class Statistics {
 
     public long getNumNeutronFaults() {
         return numNeutronFaults;
+    }
+
+    public List<LaneStatistics> getPerLane() {
+        return perLane;
     }
 
     public static class Builder {
@@ -92,6 +103,11 @@ public class Statistics {
             return this;
         }
 
+        public Builder perLane(List<LaneStatistics> perLane) {
+            instance.perLane = perLane != null ? perLane : new ArrayList<>();
+            return this;
+        }
+
         public Statistics build() {
             return instance;
         }
@@ -108,11 +124,121 @@ public class Statistics {
                 .numGammaFaults(this.numGammaFaults + other.numGammaFaults)
                 .numNeutronFaults(this.numNeutronFaults + other.numNeutronFaults)
                 .numTampers(this.numTampers + other.numTampers)
+                .perLane(mergePerLane(this.perLane, other.perLane))
                 .build();
     }
 
     public static Statistics zero() {
         return new Statistics.Builder().build(); // all zeros
+    }
+
+    // Merge two per-lane lists by laneUID, summing counts and weighting the
+    // adjudication-latency average by adjudication count.
+    private static List<LaneStatistics> mergePerLane(List<LaneStatistics> a, List<LaneStatistics> b) {
+        if ((a == null || a.isEmpty()) && (b == null || b.isEmpty()))
+            return new ArrayList<>();
+
+        Map<String, LaneStatistics> merged = new LinkedHashMap<>();
+        if (a != null) for (var s : a) merged.put(s.getLaneUID(), s);
+        if (b != null) {
+            for (var rhs : b) {
+                var lhs = merged.get(rhs.getLaneUID());
+                merged.put(rhs.getLaneUID(), lhs == null ? rhs : lhs.add(rhs));
+            }
+        }
+        return new ArrayList<>(merged.values());
+    }
+
+    /**
+     * Per-lane breakdown carried alongside the node-level counts. Adjudication
+     * latency is stored in seconds and combined with a count-weighted average.
+     */
+    public static class LaneStatistics {
+        private final String laneUID;
+        private final long numOccupancies;
+        private final long numGammaAlarms;
+        private final long numNeutronAlarms;
+        private final long numGammaNeutronAlarms;
+        private final long numFaults;
+        private final long numGammaFaults;
+        private final long numNeutronFaults;
+        private final long numTampers;
+        private final long numAdjudicated;
+        private final double avgTimeToAdjudicateSec;
+
+        private LaneStatistics(Builder b) {
+            this.laneUID = b.laneUID;
+            this.numOccupancies = b.numOccupancies;
+            this.numGammaAlarms = b.numGammaAlarms;
+            this.numNeutronAlarms = b.numNeutronAlarms;
+            this.numGammaNeutronAlarms = b.numGammaNeutronAlarms;
+            this.numFaults = b.numFaults;
+            this.numGammaFaults = b.numGammaFaults;
+            this.numNeutronFaults = b.numNeutronFaults;
+            this.numTampers = b.numTampers;
+            this.numAdjudicated = b.numAdjudicated;
+            this.avgTimeToAdjudicateSec = b.avgTimeToAdjudicateSec;
+        }
+
+        public String getLaneUID() { return laneUID; }
+        public long getNumOccupancies() { return numOccupancies; }
+        public long getNumGammaAlarms() { return numGammaAlarms; }
+        public long getNumNeutronAlarms() { return numNeutronAlarms; }
+        public long getNumGammaNeutronAlarms() { return numGammaNeutronAlarms; }
+        public long getNumFaults() { return numFaults; }
+        public long getNumGammaFaults() { return numGammaFaults; }
+        public long getNumNeutronFaults() { return numNeutronFaults; }
+        public long getNumTampers() { return numTampers; }
+        public long getNumAdjudicated() { return numAdjudicated; }
+        public double getAvgTimeToAdjudicateSec() { return avgTimeToAdjudicateSec; }
+
+        public LaneStatistics add(LaneStatistics other) {
+            long totalAdj = this.numAdjudicated + other.numAdjudicated;
+            double avg = totalAdj == 0 ? 0.0
+                    : (this.avgTimeToAdjudicateSec * this.numAdjudicated
+                       + other.avgTimeToAdjudicateSec * other.numAdjudicated) / totalAdj;
+            return new Builder()
+                    .laneUID(this.laneUID)
+                    .numOccupancies(this.numOccupancies + other.numOccupancies)
+                    .numGammaAlarms(this.numGammaAlarms + other.numGammaAlarms)
+                    .numNeutronAlarms(this.numNeutronAlarms + other.numNeutronAlarms)
+                    .numGammaNeutronAlarms(this.numGammaNeutronAlarms + other.numGammaNeutronAlarms)
+                    .numFaults(this.numFaults + other.numFaults)
+                    .numGammaFaults(this.numGammaFaults + other.numGammaFaults)
+                    .numNeutronFaults(this.numNeutronFaults + other.numNeutronFaults)
+                    .numTampers(this.numTampers + other.numTampers)
+                    .numAdjudicated(totalAdj)
+                    .avgTimeToAdjudicateSec(avg)
+                    .build();
+        }
+
+        public static class Builder {
+            private String laneUID = "";
+            private long numOccupancies;
+            private long numGammaAlarms;
+            private long numNeutronAlarms;
+            private long numGammaNeutronAlarms;
+            private long numFaults;
+            private long numGammaFaults;
+            private long numNeutronFaults;
+            private long numTampers;
+            private long numAdjudicated;
+            private double avgTimeToAdjudicateSec;
+
+            public Builder laneUID(String v) { this.laneUID = v; return this; }
+            public Builder numOccupancies(long v) { this.numOccupancies = v; return this; }
+            public Builder numGammaAlarms(long v) { this.numGammaAlarms = v; return this; }
+            public Builder numNeutronAlarms(long v) { this.numNeutronAlarms = v; return this; }
+            public Builder numGammaNeutronAlarms(long v) { this.numGammaNeutronAlarms = v; return this; }
+            public Builder numFaults(long v) { this.numFaults = v; return this; }
+            public Builder numGammaFaults(long v) { this.numGammaFaults = v; return this; }
+            public Builder numNeutronFaults(long v) { this.numNeutronFaults = v; return this; }
+            public Builder numTampers(long v) { this.numTampers = v; return this; }
+            public Builder numAdjudicated(long v) { this.numAdjudicated = v; return this; }
+            public Builder avgTimeToAdjudicateSec(double v) { this.avgTimeToAdjudicateSec = v; return this; }
+
+            public LaneStatistics build() { return new LaneStatistics(this); }
+        }
     }
 
 }

--- a/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/StatisticsControl.java
+++ b/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/StatisticsControl.java
@@ -1,6 +1,7 @@
 package com.botts.impl.service.oscar.stats;
 
 import com.botts.impl.service.oscar.OSCARSystem;
+import net.opengis.swe.v20.DataArray;
 import net.opengis.swe.v20.DataBlock;
 import net.opengis.swe.v20.DataComponent;
 import org.sensorhub.api.command.*;
@@ -28,7 +29,10 @@ public class StatisticsControl extends AbstractSensorControl<OSCARSystem> implem
         statsOutput = (StatisticsOutput) parentSensor.getOutputs().get(StatisticsOutput.NAME);
 
         RADHelper fac = new RADHelper();
-        resultDescription = fac.createCountStatistics();
+        // Same bucket shape as one of the four buckets inside the published
+        // siteStatistics observation, so custom-range responses carry the
+        // per-lane breakdown too.
+        resultDescription = fac.createBucketStatistics("Custom Range Total", "CustomCount");
         commandDescription = fac.createRecord()
                 .name(NAME)
                 .label(LABEL)
@@ -59,9 +63,14 @@ public class StatisticsControl extends AbstractSensorControl<OSCARSystem> implem
 
             ICommandResult result;
             if (start != null) {
-                // TODO: Return result of createCountStatistics
+                Statistics stats = statsOutput.getStatsForRange(start, end);
+                // Size the per-lane array before allocating so the data block
+                // has the right number of trailing atoms.
+                ((DataArray) resultDescription.getComponent("byLane"))
+                        .updateSize(stats.getPerLane().size());
                 DataBlock resultData = resultDescription.createDataBlock();
-                statsOutput.populateDataBlock(resultData, 0, start, end);
+                resultDescription.setData(resultData);
+                statsOutput.populateBucket(resultData, 0, stats);
                 result = CommandResult.withData(resultData);
             } else {
                 // TODO: Call update for latest site statistics output, and return output observation id

--- a/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/StatisticsOutput.java
+++ b/services/sensorhub-service-oscar/src/main/java/com/botts/impl/service/oscar/stats/StatisticsOutput.java
@@ -1,15 +1,21 @@
 package com.botts.impl.service.oscar.stats;
 
 import com.botts.impl.service.oscar.OSCARSystem;
+import net.opengis.swe.v20.DataArray;
 import net.opengis.swe.v20.DataBlock;
 import net.opengis.swe.v20.DataComponent;
 import net.opengis.swe.v20.DataEncoding;
 import net.opengis.swe.v20.DataRecord;
+import org.sensorhub.api.command.ICommandStatus;
 import org.sensorhub.api.common.BigId;
+import org.sensorhub.api.common.IdEncoder;
 import org.sensorhub.api.data.DataEvent;
 import org.sensorhub.api.database.IObsSystemDatabase;
+import org.sensorhub.api.datastore.command.CommandFilter;
+import org.sensorhub.api.datastore.command.CommandStatusFilter;
 import org.sensorhub.api.datastore.obs.DataStreamFilter;
 import org.sensorhub.api.datastore.obs.ObsFilter;
+import org.sensorhub.api.datastore.system.SystemFilter;
 import org.sensorhub.api.resource.ResourceKey;
 import org.sensorhub.impl.sensor.AbstractSensorOutput;
 import org.sensorhub.impl.utils.rad.RADHelper;
@@ -30,6 +36,11 @@ import java.util.stream.Collectors;
 public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
 
     public static final String NAME = "siteStatistics";
+
+    // Mirrors LaneSystem.LANE_SYSTEM_PREFIX (kept private there). All lane
+    // systems registered via the lane module use this UID prefix, so a trailing
+    // '*' wildcard in withUniqueIDs() selects every lane on the hub.
+    public static final String LANE_UID_PREFIX = "urn:osh:system:lane:";
 
     public static String gammaNeutronAlarmCQL = "gammaAlarm = true AND neutronAlarm = true";
     public static String gammaAlarmCQL = "gammaAlarm = true AND neutronAlarm = false";
@@ -53,15 +64,17 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
 
     private ScheduledExecutorService service;
     private final IObsSystemDatabase database;
+    private final IdEncoder obsIdEncoder;
     private Map<String, Set<BigId>> observedPropertyToDataStreamIds;
 
     private record LastStatisticObservationData(Instant timestamp, Statistics total) {
 
     }
 
-    public StatisticsOutput(OSCARSystem parentSensor, IObsSystemDatabase database, int samplingPeriod) {
+    public StatisticsOutput(OSCARSystem parentSensor, IObsSystemDatabase database, IdEncoder obsIdEncoder, int samplingPeriod) {
         super(NAME, parentSensor);
         this.database = database;
+        this.obsIdEncoder = obsIdEncoder;
         RADHelper fac = new RADHelper();
         recordDescription = fac.createSiteStatistics();
         recommendedEncoding = new TextEncodingImpl();
@@ -111,44 +124,74 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
     }
 
     public void publishLatestStatistics() {
+        try {
+            publishLatestStatisticsInternal();
+        } catch (Throwable t) {
+            // scheduleAtFixedRate silently suppresses exceptions and stops
+            // re-scheduling — surface them so they don't disappear.
+            getLogger().error("publishLatestStatistics failed", t);
+            throw t;
+        }
+    }
+
+    private void publishLatestStatisticsInternal() {
         initializeDataStreamMapping();
         getLogger().info("Starting stats counting...");
         long currentTime = System.currentTimeMillis();
-
-        DataBlock dataBlock = latestRecord == null ? recordDescription.createDataBlock() : latestRecord.renew();
         Instant now = Instant.now();
 
-        int i = 0;
-        dataBlock.setLongValue(i++, currentTime/1000);
-
-        // Get total counts from all observations
-        LastStatisticObservationData lastStatisticObservationData = getLastObservation();
-
-        if (lastStatisticObservationData != null) {
-            Instant lastTimestamp = lastStatisticObservationData.timestamp();
-            Statistics previousTotal = lastStatisticObservationData.total();
-            Instant exclusiveStart = lastTimestamp.plusNanos(1);
-            Statistics incrementalStats = getStats(exclusiveStart, now);
-
-            Statistics newTotal = previousTotal.add(incrementalStats);
-
-            i = populateDataBlockWithStats(dataBlock, i, newTotal);
+        // Compute all four buckets up front so we know each per-lane array
+        // size before allocating the data block (variable-size SWE arrays
+        // can't grow once createDataBlock() returns).
+        Statistics allTimeStats;
+        LastStatisticObservationData lastObs = getLastObservation();
+        if (lastObs != null) {
+            // Preserve the existing all-time incremental optimization for the
+            // node-wide counts; recompute the per-lane breakdown fresh so it
+            // reflects current lane membership.
+            Statistics incrementalStats = getStats(lastObs.timestamp().plusNanos(1), now);
+            Statistics newTotals = lastObs.total().add(incrementalStats);
+            List<Statistics.LaneStatistics> freshPerLane = getStats(Instant.EPOCH, now).getPerLane();
+            allTimeStats = new Statistics.Builder()
+                    .numOccupancies(newTotals.getNumOccupancies())
+                    .numGammaAlarms(newTotals.getNumGammaAlarms())
+                    .numNeutronAlarms(newTotals.getNumNeutronAlarms())
+                    .numGammaNeutronAlarms(newTotals.getNumGammaNeutronAlarms())
+                    .numFaults(newTotals.getNumFaults())
+                    .numGammaFaults(newTotals.getNumGammaFaults())
+                    .numNeutronFaults(newTotals.getNumNeutronFaults())
+                    .numTampers(newTotals.getNumTampers())
+                    .perLane(freshPerLane)
+                    .build();
         } else {
             getLogger().debug("No previous stats observation found, calculating from epoch to {}", now);
-            i = populateDataBlock(dataBlock, i, Instant.EPOCH, now);
+            allTimeStats = getStats(Instant.EPOCH, now);
         }
 
-        // last 30 days
-        Instant monthStart = now.minus(30, ChronoUnit.DAYS);
-        i = populateDataBlock(dataBlock, i, monthStart, now);
+        Statistics monthlyStats = getStats(now.minus(30, ChronoUnit.DAYS), now);
+        Statistics weeklyStats  = getStats(now.minus(7,  ChronoUnit.DAYS), now);
+        Statistics dailyStats   = getStats(now.minus(24, ChronoUnit.HOURS), now);
 
-        // last 7 days
-        Instant weekStart = now.minus(7, ChronoUnit.DAYS);
-        i = populateDataBlock(dataBlock, i, weekStart, now);
+        // Resize each bucket's "byLane" array to match the lanes we found.
+        sizeBucketArray("allTime", allTimeStats.getPerLane().size());
+        sizeBucketArray("monthly", monthlyStats.getPerLane().size());
+        sizeBucketArray("weekly",  weeklyStats.getPerLane().size());
+        sizeBucketArray("daily",   dailyStats.getPerLane().size());
 
-        // last 24 hours
-        Instant dayStart = now.minus(24, ChronoUnit.HOURS);
-        populateDataBlock(dataBlock, i, dayStart, now);
+        // Always allocate fresh; latestRecord.renew() can't grow var-size arrays.
+        // createDataBlock() honours the per-lane sizes we just set above, so we
+        // skip the recursive setData() consistency check (which compares each
+        // array's count-component value against its allocated atom count — that
+        // value is still 0 in the freshly-allocated block until we write it
+        // below).
+        DataBlock dataBlock = recordDescription.createDataBlock();
+
+        int i = 0;
+        dataBlock.setLongValue(i++, currentTime / 1000);
+        i = populateBucket(dataBlock, i, allTimeStats);
+        i = populateBucket(dataBlock, i, monthlyStats);
+        i = populateBucket(dataBlock, i, weeklyStats);
+        populateBucket(dataBlock, i, dailyStats);
 
         latestRecord = dataBlock;
         latestRecordTime = currentTime;
@@ -185,14 +228,12 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
     }
 
     /**
-     * Populates the data block with statistics for the given time range.
+     * Populates a single bucket sub-record (allTime/monthly/weekly/daily)
+     * starting at flat atom index {@code i}. Used by {@link StatisticsControl}
+     * to write custom-range responses into a standalone bucket data block.
      */
-    public int populateDataBlock(DataBlock dataBlock, int i, Instant start, Instant end) {
-        Statistics stats = getStats(start, end);
-        return populateDataBlockWithStats(dataBlock, i, stats);
-    }
-
-    private int populateDataBlockWithStats(DataBlock dataBlock, int i, Statistics stats) {
+    public int populateBucket(DataBlock dataBlock, int i, Statistics stats) {
+        // 8 base counts (must match the order in RADHelper.createCountStatistics)
         dataBlock.setLongValue(i++, stats.getNumOccupancies());
         dataBlock.setLongValue(i++, stats.getNumGammaAlarms());
         dataBlock.setLongValue(i++, stats.getNumNeutronAlarms());
@@ -201,7 +242,48 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
         dataBlock.setLongValue(i++, stats.getNumGammaFaults());
         dataBlock.setLongValue(i++, stats.getNumNeutronFaults());
         dataBlock.setLongValue(i++, stats.getNumTampers());
+
+        // numLanes + byLane array
+        var perLane = stats.getPerLane();
+        dataBlock.setIntValue(i++, perLane.size());
+        for (var lane : perLane) {
+            dataBlock.setStringValue(i++, lane.getLaneUID());
+            dataBlock.setLongValue(i++, lane.getNumOccupancies());
+            dataBlock.setLongValue(i++, lane.getNumGammaAlarms());
+            dataBlock.setLongValue(i++, lane.getNumNeutronAlarms());
+            dataBlock.setLongValue(i++, lane.getNumGammaNeutronAlarms());
+            dataBlock.setLongValue(i++, lane.getNumFaults());
+            dataBlock.setLongValue(i++, lane.getNumGammaFaults());
+            dataBlock.setLongValue(i++, lane.getNumNeutronFaults());
+            dataBlock.setLongValue(i++, lane.getNumTampers());
+            dataBlock.setLongValue(i++, lane.getNumAdjudicated());
+            dataBlock.setDoubleValue(i++, lane.getAvgTimeToAdjudicateSec());
+        }
         return i;
+    }
+
+    /**
+     * Convenience entry used by {@link StatisticsControl}: compute stats for
+     * the given window and populate into the provided bucket data block.
+     */
+    public int populateBucket(DataBlock dataBlock, int i, Instant start, Instant end) {
+        return populateBucket(dataBlock, i, getStats(start, end));
+    }
+
+    /**
+     * Resizes one bucket's per-lane SWE array so {@link #recordDescription}
+     * .createDataBlock() allocates the right number of trailing atoms.
+     */
+    public void sizeBucketArray(String bucketName, int numLanes) {
+        ((DataArray) recordDescription.getComponent(bucketName).getComponent("byLane")).updateSize(numLanes);
+    }
+
+    /**
+     * Public entry point for one-off range queries (used by
+     * {@link StatisticsControl}'s custom-range command).
+     */
+    public Statistics getStatsForRange(Instant start, Instant end) {
+        return getStats(start, end);
     }
 
     /**
@@ -233,7 +315,133 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
                 .numGammaFaults(numGammaFaults)
                 .numNeutronFaults(numNeutronFaults)
                 .numTampers(numTampers)
+                .perLane(getPerLaneStats(start, end))
                 .build();
+    }
+
+    /**
+     * Builds one {@link Statistics.LaneStatistics} per registered lane system.
+     * Returns an empty list when no lane systems are present (e.g. during
+     * fresh test bring-up before any LaneSystem is loaded).
+     */
+    private List<Statistics.LaneStatistics> getPerLaneStats(Instant start, Instant end) {
+        // Lane systems are stored as multiple validity-time versions of the same
+        // UID — select(...) returns one per version, so dedupe on UID.
+        var laneUIDs = database.getSystemDescStore()
+                .select(new SystemFilter.Builder()
+                        .withUniqueIDs(LANE_UID_PREFIX + "*")
+                        .build())
+                .map(sys -> sys.getUniqueIdentifier())
+                .distinct()
+                .collect(Collectors.toList());
+
+        var result = new ArrayList<Statistics.LaneStatistics>(laneUIDs.size());
+        for (String laneUID : laneUIDs) {
+            long occ           = countLaneObservations(laneUID, null, start, end, RADHelper.DEF_OCCUPANCY);
+            long gAlarm        = countLaneObservations(laneUID, gammaAlarmCQL, start, end, RADHelper.DEF_OCCUPANCY);
+            long nAlarm        = countLaneObservations(laneUID, neutronAlarmCQL, start, end, RADHelper.DEF_OCCUPANCY);
+            long gnAlarm       = countLaneObservations(laneUID, gammaNeutronAlarmCQL, start, end, RADHelper.DEF_OCCUPANCY);
+            long gFault        = countLaneObservations(laneUID, gammaFaultCQL, start, end, RADHelper.DEF_GAMMA, RADHelper.DEF_ALARM);
+            long nFault        = countLaneObservations(laneUID, neutronFaultCQL, start, end, RADHelper.DEF_NEUTRON, RADHelper.DEF_ALARM);
+            long tampers       = countLaneObservations(laneUID, tamperCQL, start, end, RADHelper.DEF_TAMPER);
+            long faults        = countLaneObservations(laneUID, faultCQL, start, end, RADHelper.DEF_GAMMA, RADHelper.DEF_NEUTRON, RADHelper.DEF_ALARM) + tampers;
+
+            // RS350 alarm counts roll into the same lane buckets as the
+            // node-level totals do above.
+            long rs350Gamma   = countLaneObservations(laneUID, rs350GammaAlarmCQL, start, end, DEF_ALARM_CATEGORY);
+            long rs350Neutron = countLaneObservations(laneUID, rs350NeutronAlarmCQL, start, end, DEF_ALARM_CATEGORY);
+            gAlarm += rs350Gamma;
+            nAlarm += rs350Neutron;
+            occ    += rs350Gamma + rs350Neutron;
+
+            var adj = computeAdjudicationMetrics(laneUID, start, end);
+
+            result.add(new Statistics.LaneStatistics.Builder()
+                    .laneUID(laneUID)
+                    .numOccupancies(occ)
+                    .numGammaAlarms(gAlarm)
+                    .numNeutronAlarms(nAlarm)
+                    .numGammaNeutronAlarms(gnAlarm)
+                    .numFaults(faults)
+                    .numGammaFaults(gFault)
+                    .numNeutronFaults(nFault)
+                    .numTampers(tampers)
+                    .numAdjudicated(adj.count)
+                    .avgTimeToAdjudicateSec(adj.avgSeconds)
+                    .build());
+        }
+        return result;
+    }
+
+    private record AdjudicationMetrics(long count, double avgSeconds) {}
+
+    /**
+     * Walks the lane's COMPLETED adjudication command statuses in the window
+     * and returns the count plus the mean time between the linked occupancy's
+     * phenomenon time and the adjudication's report time (seconds).
+     * Statuses whose linked occupancy can't be resolved are skipped from the
+     * average but still counted (matches what AdjudicationLog shows the user).
+     */
+    private AdjudicationMetrics computeAdjudicationMetrics(String laneUID, Instant start, Instant end) {
+        var statusStore = database.getCommandStatusStore();
+        var iter = statusStore.select(new CommandStatusFilter.Builder()
+                .withStatus(ICommandStatus.CommandStatusCode.COMPLETED)
+                .withReportTimeDuring(start, end)
+                .withCommands(new CommandFilter.Builder()
+                        .withSystems().withUniqueIDs(laneUID).done()
+                        .build())
+                .build()).iterator();
+
+        long count = 0;
+        double sumSeconds = 0.0;
+        long timedCount = 0;
+        while (iter.hasNext()) {
+            var status = iter.next();
+            count++;
+
+            try {
+                var records = status.getResult().getInlineRecords().stream().toList();
+                if (records.isEmpty())
+                    continue;
+                var record = records.get(0);
+
+                // Adjudication result layout (see AdjudicationControl.createResultData):
+                //   0: username, 1: feedback, 2: code, 3: isotopeCount,
+                //   4..N: isotopes, N+1: secondaryInspection, N+2: filePathCount,
+                //   N+3..M: filePaths, M+1: occupancyObsId, M+2: vehicleId
+                int idx = 3;
+                int isotopeCount = record.getIntValue(idx++);
+                idx += isotopeCount;       // skip isotopes
+                idx++;                     // skip secondaryInspectionStatus
+                int filePathCount = record.getIntValue(idx++);
+                idx += filePathCount;      // skip file paths
+                String occupancyObsId = record.getStringValue(idx);
+
+                if (occupancyObsId == null || occupancyObsId.isBlank())
+                    continue;
+
+                BigId decoded = obsIdEncoder.decodeID(occupancyObsId);
+                if (decoded == null)
+                    continue;
+
+                var occupancyObs = database.getObservationStore().get(decoded);
+                if (occupancyObs == null)
+                    continue;
+
+                double seconds = (status.getReportTime().toEpochMilli()
+                        - occupancyObs.getPhenomenonTime().toEpochMilli()) / 1000.0;
+                if (seconds < 0)
+                    continue;
+
+                sumSeconds += seconds;
+                timedCount++;
+            } catch (Exception e) {
+                getLogger().debug("Skipping adjudication latency entry for lane {}: {}", laneUID, e.getMessage());
+            }
+        }
+
+        double avg = timedCount == 0 ? 0.0 : sumSeconds / timedCount;
+        return new AdjudicationMetrics(count, avg);
     }
 
     /**
@@ -252,6 +460,30 @@ public class StatisticsOutput extends AbstractSensorOutput<OSCARSystem> {
         }
 
         if (cqlValue != null &&  !cqlValue.isBlank()) {
+            obsBuilder.withCQLFilter(cqlValue);
+        }
+
+        return database.getObservationStore().countMatchingEntries(obsBuilder.build());
+    }
+
+    /**
+     * Lane-scoped version of {@link #countObservations}: restricts the
+     * datastream filter to those owned by (or nested under) the given lane UID.
+     * Mirrors reports/helpers/Utils#countObservationsFromLane.
+     */
+    private long countLaneObservations(String laneUID, String cqlValue, Instant begin, Instant end, String... observedProperty) {
+        var dsFilter = new DataStreamFilter.Builder()
+                .withSystems().withUniqueIDs(laneUID).includeMembers(true).done()
+                .withObservedProperties(observedProperty)
+                .build();
+
+        var obsBuilder = new ObsFilter.Builder().withDataStreams(dsFilter);
+
+        if (begin != null && end != null) {
+            obsBuilder.withPhenomenonTime().withRange(begin, end).done();
+        }
+
+        if (cqlValue != null && !cqlValue.isBlank()) {
             obsBuilder.withCQLFilter(cqlValue);
         }
 

--- a/services/sensorhub-service-oscar/src/test/java/com/botts/impl/service/oscar/StatisticsTests.java
+++ b/services/sensorhub-service-oscar/src/test/java/com/botts/impl/service/oscar/StatisticsTests.java
@@ -6,6 +6,8 @@ import com.botts.impl.service.bucket.BucketServiceConfig;
 import com.botts.impl.service.oscar.siteinfo.SiteDiagramConfig;
 import com.botts.impl.service.oscar.stats.StatisticsControl;
 import com.botts.impl.service.oscar.stats.StatisticsOutput;
+import net.opengis.swe.v20.DataArray;
+import net.opengis.swe.v20.DataRecord;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -194,6 +196,61 @@ public class StatisticsTests {
     public void testRaceCondition() throws ExecutionException, InterruptedException {
         for (int i = 0; i < 200; i++)
             testVerifyOutputLatestObsFromCommand();
+    }
+
+    /**
+     * Each of the four time-bucket sub-records must expose a numLanes counter
+     * and a byLane variable-size array of lane-stat records — the frontend
+     * detail panel parses these fields directly.
+     */
+    @Test
+    public void testSiteStatisticsSchemaIncludesByLaneArray() {
+        var schema = statsOutput.getRecordDescription();
+        for (var bucketName : new String[] { "allTime", "monthly", "weekly", "daily" }) {
+            var bucket = schema.getComponent(bucketName);
+            assertNotNull("Missing bucket sub-record: " + bucketName, bucket);
+            assertNotNull("Missing numLanes in " + bucketName, bucket.getComponent("numLanes"));
+
+            var byLane = bucket.getComponent("byLane");
+            assertNotNull("Missing byLane array in " + bucketName, byLane);
+            assertTrue(bucketName + ".byLane should be a DataArray", byLane instanceof DataArray);
+
+            var element = ((DataArray) byLane).getElementType();
+            assertTrue(bucketName + ".byLane element should be a record", element instanceof DataRecord);
+            for (var field : new String[] {
+                    "laneId", "numOccupancies", "numGammaAlarms", "numNeutronAlarms",
+                    "numGammaNeutronAlarms", "numFaults", "numGammaFaults", "numNeutronFaults",
+                    "numTampers", "numAdjudicated", "avgTimeToAdjudicateSec" }) {
+                assertNotNull("Missing per-lane field " + field + " in " + bucketName,
+                        element.getComponent(field));
+            }
+        }
+    }
+
+    /**
+     * With no lane systems registered, the published observation must still
+     * report numLanes = 0 in every bucket (and not crash trying to populate
+     * an empty per-lane array).
+     */
+    @Test
+    public void testPublishedObservationHasZeroLanesWhenNoLanes() {
+        statsOutput.publishLatestStatistics();
+        var record = statsOutput.getLatestRecord();
+        assertNotNull(record);
+
+        var schema = statsOutput.getRecordDescription();
+        // The flat atom index for "numLanes" inside each bucket sits right
+        // after the 8 count fields (numOccupancies..numTampers). The first
+        // bucket starts at index 1 (index 0 is samplingTime).
+        int bucketAtomCount = 8 + 1; // 8 counts + numLanes (byLane has 0 elements)
+        int i = 1;
+        for (var bucketName : new String[] { "allTime", "monthly", "weekly", "daily" }) {
+            int numLanesIdx = i + 8;
+            assertEquals("Expected numLanes=0 in bucket " + bucketName,
+                    0, record.getIntValue(numLanesIdx));
+            i += bucketAtomCount;
+            assertNotNull(schema.getComponent(bucketName));
+        }
     }
 
     private OSCARServiceConfig createOscarServiceConfig() throws SensorHubException {


### PR DESCRIPTION
Extends the OSCAR `siteStatistics` observation with a per-lane breakdown under each time bucket (allTime, monthly, weekly, daily). Each bucket now carries `numLanes` + a `byLane` array, where every entry holds the eight standard counts plus `numAdjudicated` and `avgTimeToAdjudicateSec` for that lane.

- `RADHelper`: new `createLaneCountStatistics` + `createBucketStatistics` helpers; `createSiteStatistics` now adds `byLane` to each bucket.
- `Statistics`: nested `LaneStatistics` class with a count-weighted merge that keeps incremental all-time totals correct.
- `StatisticsOutput`: enumerates lane systems via `withUniqueIDs("urn:osh:system:lane:*")`, reuses CQL counts per lane, and queries the `CommandStatusStore` to compute `numAdjudicated` and the mean `reportTime - phenomenonTime` gap for COMPLETED adjudications. Wraps `publishLatestStatistics` in a try/catch so the executor doesn't silently suppress exceptions, and skips `recordDescription.setData` so the variable-array consistency check doesn't fire on fresh data blocks.
- `StatisticsControl`: custom-range responses now share the per-bucket schema so they include `byLane`.
- `StatisticsTests`: schema-shape and zero-lane-publish assertions.

Companion viewer PR (Botts-Innovative-Research/oscar-viewer #280, updated) consumes `byLane` to render an expandable per-lane breakdown on National View.