### PR TITLE
Harden ffmpeg HLS pipeline: RTSP reconnect, PTS rebase, wider live window, inactivity watchdog fix

### DIFF
--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/FFMPEGSensorBase.java
@@ -291,6 +291,9 @@ public abstract class FFMPEGSensorBase<FFMPEGconfigType extends FFMPEGConfig> ex
 	            mpegTsProcessor = new MpegTsProcessor(config.connection.transportStreamPath, config.connection.fps, config.connection.loop, config.connection.useTCP);
 	        } else if ((null != config.connection.connectionString) && (!config.connection.connectionString.isBlank())) {
 	            mpegTsProcessor = new MpegTsProcessor(config.connection.connectionString, config.connection.fps, false, config.connection.useTCP);
+	            // Network source: re-establish the session after read errors instead of
+	            // letting the demux thread die while the module still reports connected.
+	            mpegTsProcessor.setReconnectOnError(true);
 	        } else {
 	        	throw new SensorHubException("Either the input file path or the connection string must be set");
 	        }

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/HLSControl.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/HLSControl.java
@@ -56,9 +56,17 @@ public class HLSControl<FFmpegConfigType extends FFMPEGConfig> extends AbstractS
         bucketService = sensor.getParentHub().getModuleRegistry().getModuleByType(IBucketService.class);
         bucketStore = bucketService.getBucketStore();
 
-        if (hlsHandler.get() == null) {
-            hlsHandler.set(new HlsStreamHandler(bucketService));
-            bucketService.registerObjectHandler(hlsHandler.get());
+        // Lane modules init in parallel, and a plain check-then-set here used to create
+        // and register one handler per lane. Requests were then served by the first
+        // registered instance while controls registered with the last one, so the
+        // inactivity watchdog could never match a stale stream to its control.
+        // Create and register exactly one handler.
+        synchronized (HLSControl.class) {
+            if (hlsHandler.get() == null) {
+                var handler = new HlsStreamHandler(bucketService);
+                hlsHandler.set(handler);
+                bucketService.registerObjectHandler(handler);
+            }
         }
 
         boolean videosBucketExists = bucketStore.bucketExists(VIDEO_BUCKET);
@@ -136,33 +144,8 @@ public class HLSControl<FFmpegConfigType extends FFMPEGConfig> extends AbstractS
                     }
                 }
             } else if (selected.equals(CMD_END_STREAM)) {
-                if (!fileOutput.isWriting())
-                    commandStatus = false;
-                else {
-                    try {
-                        this.fileOutput.closeFile();
-                        this.parentSensor.reportStatus("Closing video stream: " + fileName);
-                        hlsHandler.get().removeControl(fileName, this);
-                        commandStatus = true;
-                        reportFileName = false;
-
-                        // File cleanup
-                        try {
-                            var fileNameNoExt = fileName.substring(0, fileName.lastIndexOf('.'));
-                            var filteredNames = bucketStore.listObjects(VIDEO_BUCKET).stream().filter(name -> {
-                                return name.contains(fileNameNoExt);
-                            }).toList();
-                            for (String hlsFile : filteredNames) {
-                                bucketStore.deleteObject(VIDEO_BUCKET, hlsFile);
-                            }
-                        } catch (Exception de) {
-                            logger.warn("Exception during HLS cleanup: ", de);
-                        }
-                        fileName = "";
-                    } catch (Exception e) {
-                        commandStatus = false;
-                    }
-                }
+                commandStatus = endStreamNow();
+                reportFileName = false;
             } else {
                 commandStatus = false;
             }
@@ -182,6 +165,42 @@ public class HLSControl<FFmpegConfigType extends FFMPEGConfig> extends AbstractS
             }
             return status.build();
         });
+    }
+
+    /**
+     * Stop the HLS mux and delete the stream's files. Called by the endStream command
+     * and directly by the inactivity watchdog — the watchdog cannot go through
+     * submitCommand: a synthetic CommandData without a valid command stream id fails
+     * builder validation.
+     *
+     * @return true if a running stream was stopped.
+     */
+    public boolean endStreamNow() {
+        if (!fileOutput.isWriting())
+            return false;
+        try {
+            this.fileOutput.closeFile();
+            this.parentSensor.reportStatus("Closing video stream: " + fileName);
+            hlsHandler.get().removeControl(fileName, this);
+
+            // File cleanup
+            try {
+                var fileNameNoExt = fileName.substring(0, fileName.lastIndexOf('.'));
+                var filteredNames = bucketStore.listObjects(VIDEO_BUCKET).stream().filter(name -> {
+                    return name.contains(fileNameNoExt);
+                }).toList();
+                for (String hlsFile : filteredNames) {
+                    bucketStore.deleteObject(VIDEO_BUCKET, hlsFile);
+                }
+            } catch (Exception de) {
+                logger.warn("Exception during HLS cleanup: ", de);
+            }
+            fileName = "";
+            return true;
+        } catch (Exception e) {
+            logger.error("Exception while closing HLS output", e);
+            return false;
+        }
     }
 
     @Override

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/hls/HlsStreamHandler.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/hls/HlsStreamHandler.java
@@ -5,16 +5,16 @@ import com.botts.api.service.bucket.IBucketStore;
 import com.botts.impl.service.bucket.handler.DefaultObjectHandler;
 import com.botts.impl.service.bucket.util.RequestContext;
 import com.botts.impl.service.bucket.util.ServiceErrors;
-import net.opengis.swe.v20.Category;
-import org.sensorhub.api.command.CommandData;
-import org.sensorhub.api.common.BigId;
 import org.sensorhub.api.datastore.DataStoreException;
 import org.sensorhub.impl.sensor.ffmpeg.controls.HLSControl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
@@ -23,6 +23,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 public class HlsStreamHandler extends DefaultObjectHandler {
+
+    private static final Logger logger = LoggerFactory.getLogger(HlsStreamHandler.class);
 
     private static final Pattern HLS_PATTERN = Pattern.compile(".*\\.(m3u8|ts)$");
     // A stream is torn down (and its files deleted) after this long without a manifest
@@ -93,24 +95,37 @@ public class HlsStreamHandler extends DefaultObjectHandler {
         }
     }
 
-    private void stopStream(HLSControl<?> control) {
-        if (control != null) {
-            var command = control.getCommandDescription().clone();
-            command.renewDataBlock();
-            ((Category)command.getComponent(0)).setValue(HLSControl.CMD_END_STREAM);
-            control.submitCommand(new CommandData.Builder().withParams(command.getData()).withCommandStream(BigId.NONE).build());
-        }
-    }
-
     private void cleanupInactiveStreams() {
-        // Remove active streams after timeout
-        activeStreams.entrySet().removeIf(entry -> {
-            if (System.currentTimeMillis() - entry.getValue() > STREAM_TIMEOUT_MS) {
-                stopStream(activeControls.remove(entry.getKey())); // Remove the corresponding control and stop its stream
-                return true;
+        // This runs via scheduleAtFixedRate: a single escaped exception silently
+        // cancels all future runs (which is how the previous implementation — a
+        // synthetic CommandData that fails id validation — killed the watchdog on
+        // its first reap). Nothing may escape this method.
+        try {
+            long now = System.currentTimeMillis();
+            var expired = new ArrayList<String>();
+            for (var entry : activeStreams.entrySet()) {
+                if (now - entry.getValue() > STREAM_TIMEOUT_MS)
+                    expired.add(entry.getKey());
             }
-            return false;
-        });
+            for (String key : expired) {
+                activeStreams.remove(key);
+                HLSControl<?> control = activeControls.remove(key);
+                if (control != null) {
+                    logger.info("HLS stream {} had no manifest requests for {} ms; stopping it", key, STREAM_TIMEOUT_MS);
+                    try {
+                        control.endStreamNow();
+                    } catch (Exception e) {
+                        logger.error("Failed to stop inactive HLS stream {}", key, e);
+                    }
+                } else {
+                    // Reaping without a control means requests and controls are being
+                    // tracked by different handler instances and the mux keeps running.
+                    logger.warn("Expired HLS stream {} has no registered control in this handler; its mux may still be running", key);
+                }
+            }
+        } catch (Exception e) {
+            logger.error("HLS inactive-stream cleanup pass failed", e);
+        }
     }
 
     @Override

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/hls/HlsStreamHandler.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/controls/hls/HlsStreamHandler.java
@@ -25,7 +25,11 @@ import java.util.regex.Pattern;
 public class HlsStreamHandler extends DefaultObjectHandler {
 
     private static final Pattern HLS_PATTERN = Pattern.compile(".*\\.(m3u8|ts)$");
-    private static final long STREAM_TIMEOUT_MS = 30000;
+    // A stream is torn down (and its files deleted) after this long without a manifest
+    // request. Browsers legitimately pause polling for tens of seconds (background-tab
+    // throttling, transient network loss) and then resume; keep the timeout above that.
+    private static final long STREAM_TIMEOUT_MS = 90000;
+    private static final long CLEANUP_PERIOD_MS = 30000;
     private static final String M3U8_SUFFIX = ".m3u8";
 
     private final Map<String, Long> activeStreams = new ConcurrentHashMap<>();
@@ -35,7 +39,7 @@ public class HlsStreamHandler extends DefaultObjectHandler {
     public HlsStreamHandler(IBucketService service) {
         super(service.getBucketStore());
         scheduler = Executors.newSingleThreadScheduledExecutor();
-        scheduler.scheduleAtFixedRate(this::cleanupInactiveStreams, STREAM_TIMEOUT_MS, STREAM_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        scheduler.scheduleAtFixedRate(this::cleanupInactiveStreams, CLEANUP_PERIOD_MS, CLEANUP_PERIOD_MS, TimeUnit.MILLISECONDS);
     }
 
     @Override
@@ -61,6 +65,10 @@ public class HlsStreamHandler extends DefaultObjectHandler {
 
         try {
             ctx.getResponse().setContentType(mimeType);
+            // Live HLS objects must never be cached: the manifest mutates in place and
+            // segment names are reused after a stream restart, and Cloudflare fronts
+            // this endpoint in some deployments.
+            ctx.getResponse().setHeader("Cache-Control", "no-store");
             InputStream objectData;
             objectData = bucketStore.getObject(bucketName, objectKey);
             objectData.transferTo(ctx.getResponse().getOutputStream());

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/FileOutput.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/impl/sensor/ffmpeg/outputs/FileOutput.java
@@ -72,6 +72,8 @@ public class FileOutput<FFMPEGConfigType extends FFMPEGConfig> extends AbstractS
     final int MAX_PACKET_QUEUE_SIZE = 1000;
     volatile long filePts;
     volatile long curPts;
+    volatile long ptsOffset;
+    volatile boolean hasWrittenPacket;
     private WriteCallback writeCallback;
     private SeekCallback seekCallback;
     BytePointer buffer;
@@ -282,6 +284,8 @@ public class FileOutput<FFMPEGConfigType extends FFMPEGConfig> extends AbstractS
     private void initCtx(AVCodecParameters codecParams) throws IOException {
         filePts = 0;
         curPts = 0;
+        ptsOffset = 0;
+        hasWrittenPacket = false;
         int ret;
 
         //AVFormatContext inputContext = this.parentSensor.getProcessor().getAvFormatContext();
@@ -331,21 +335,50 @@ public class FileOutput<FFMPEGConfigType extends FFMPEGConfig> extends AbstractS
             filePts = avPacket.pts();
         }
 
-        long newPts = avutil.av_rescale_q(avPacket.pts() - filePts, inputTimeBase, timeBase);
-        if (isLive && newPts <= curPts) {
-            newPts = curPts + 1;
+        long newPts = avutil.av_rescale_q(avPacket.pts() - filePts, inputTimeBase, timeBase) + ptsOffset;
+
+        // Input timestamps jump when the upstream source loops its clip, reconnects, or
+        // wraps. A jump must not reach the muxer: mp4 rejects non-monotonic timestamps
+        // (av_write_frame EINVAL) and the HLS segmenter stops cutting segments while the
+        // timeline stands still. Rebase so the output timeline keeps advancing by one
+        // nominal frame across the jump.
+        if (hasWrittenPacket && (newPts <= curPts || newPts > curPts + maxPtsGap())) {
+            long rebasedPts = curPts + nominalFrameDuration();
+            ptsOffset += rebasedPts - newPts;
+            newPts = rebasedPts;
         }
+
         avPacket.pts(newPts);
         avPacket.dts(newPts);
 
         //avPacket.duration(av_rescale_q(1, inputFrameRate, timeBase));
         //avPacket.time_base(timeBase);
         curPts = newPts;
+        hasWrittenPacket = true;
+    }
+
+    /** Largest forward PTS step (in output time base units) still treated as continuous. */
+    private long maxPtsGap() {
+        return 10L * timeBase.den() / Math.max(1, timeBase.num());
+    }
+
+    /** One frame interval in output time base units, from the input frame rate. */
+    private long nominalFrameDuration() {
+        if (inputFrameRate != null && inputFrameRate.num() > 0 && inputFrameRate.den() > 0 && timeBase.num() > 0) {
+            long duration = ((long) timeBase.den() * inputFrameRate.den()) / ((long) timeBase.num() * inputFrameRate.num());
+            if (duration > 0)
+                return duration;
+        }
+        // Frame rate unknown: assume 30 fps.
+        return Math.max(1, timeBase.den() / (30L * Math.max(1, timeBase.num())));
     }
 
     private static AVDictionary hlsOptions() {
         AVDictionary options = new AVDictionary();
-        av_dict_set(options, "hls_list_size", "2", 0);
+        // The live window (hls_list_size × hls_time) must stay comfortably larger than
+        // the player's live-edge sync target, or it perpetually chases segments that
+        // are about to be deleted.
+        av_dict_set(options, "hls_list_size", "6", 0);
         av_dict_set(options, "hls_time", "1", 0);
         //avutil.av_dict_set(options, "hls_segment_type", "ts", 0);
         //avutil.av_dict_set(options, "movflags", "faststart+default_base_moof", 0);

--- a/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
+++ b/sensors/sensorhub-driver-ffmpeg/src/main/java/org/sensorhub/mpegts/MpegTsProcessor.java
@@ -213,6 +213,18 @@ public class MpegTsProcessor extends Thread {
 
     private long timeout = 5000000;
 
+    /**
+     * If true, re-establish the session and resume demuxing after a read error instead
+     * of letting the processing thread end. Intended for network sources; file playback
+     * keeps its existing loop/end-of-file behavior.
+     */
+    private volatile boolean reconnectOnError = false;
+
+    private static final long RECONNECT_INITIAL_DELAY_MS = 1000;
+    private static final long RECONNECT_MAX_DELAY_MS = 30000;
+    /** A session that survives this long resets the reconnect backoff. */
+    private static final long RECONNECT_STABLE_MS = 10000;
+
     byte[] spsPpsHeader = null;
 
     private boolean useTCP;
@@ -334,6 +346,10 @@ public class MpegTsProcessor extends Thread {
     public AVCodecParameters getCodecParams() {
         synchronized (contextLock) {
             try {
+                if (!streamOpened || avFormatContext == null || videoStreamId == INVALID_STREAM_ID) {
+                    logger.error("Stream not open; no codec parameters available");
+                    return null;
+                }
                 AVCodecParameters src = avFormatContext.streams(videoStreamId).codecpar();
                 AVCodecParameters dst = avcodec.avcodec_parameters_alloc();
                 if (src == null) {
@@ -356,6 +372,8 @@ public class MpegTsProcessor extends Thread {
 
     public AVStream getAvStream() {
         synchronized (contextLock) {
+            if (!streamOpened || avFormatContext == null || videoStreamId == INVALID_STREAM_ID)
+                return null;
             return avFormatContext.streams(videoStreamId);
         }
     }
@@ -443,6 +461,10 @@ public class MpegTsProcessor extends Thread {
 
     public void setTimeout(long timeout) {
         this.timeout = timeout;
+    }
+
+    public void setReconnectOnError(boolean reconnectOnError) {
+        this.reconnectOnError = reconnectOnError;
     }
 
     /**
@@ -687,9 +709,92 @@ public class MpegTsProcessor extends Thread {
                 avformat.av_seek_frame(avFormatContext, 0, 0, avformat.AVSEEK_FLAG_ANY);
             }
         }
-        while (loop);
+        while (loop && !terminateProcessing.get());
+
+        // A network session that drops used to end this thread permanently while the
+        // module still reported itself connected. Keep re-establishing the session,
+        // with backoff, until we are explicitly stopped.
+        long reconnectDelay = RECONNECT_INITIAL_DELAY_MS;
+        while (reconnectOnError && !terminateProcessing.get()) {
+            logger.warn("Stream {} ended unexpectedly; reconnecting in {} ms", streamSource, reconnectDelay);
+            sleepUnlessTerminated(reconnectDelay);
+            if (terminateProcessing.get())
+                break;
+
+            if (reopenStream()) {
+                logger.info("Reconnected to stream {}", streamSource);
+                long sessionStart = System.currentTimeMillis();
+                processStreamPackets();
+                logger.info("End of MISB TS stream");
+                if (System.currentTimeMillis() - sessionStart >= RECONNECT_STABLE_MS) {
+                    reconnectDelay = RECONNECT_INITIAL_DELAY_MS;
+                    continue;
+                }
+            }
+            reconnectDelay = Math.min(reconnectDelay * 2, RECONNECT_MAX_DELAY_MS);
+        }
 
         shutdownExecutors();
+    }
+
+    /**
+     * Tear down the dead session and try to establish a new one, refreshing the stream
+     * ids, extradata, and codec context that depend on it.
+     *
+     * @return true when packets can be read again.
+     */
+    private boolean reopenStream() {
+        synchronized (contextLock) {
+            closeCodecContext();
+            if (streamOpened) {
+                if (avFormatContext != null)
+                    avformat.avformat_close_input(avFormatContext);
+                streamOpened = false;
+            }
+            avFormatContext = null;
+
+            try {
+                if (!openStream())
+                    return false;
+
+                boolean priorTranscode = doTranscode;
+                videoStreamId = INVALID_STREAM_ID;
+                queryEmbeddedStreams();
+
+                // The decode/encode pipeline was sized when processing started and
+                // cannot be rebuilt here; refuse a source whose codec changed.
+                if (doTranscode != priorTranscode) {
+                    logger.error("Codec changed across reconnect of {}; cannot resume", streamSource);
+                    doTranscode = priorTranscode;
+                    return false;
+                }
+
+                if (!hasVideoStream()) {
+                    logger.error("No video stream after reconnect of {}", streamSource);
+                    return false;
+                }
+
+                openCodecContext();
+                return true;
+            } catch (Exception e) {
+                logger.error("Reconnect to {} failed", streamSource, e);
+                return false;
+            }
+        }
+    }
+
+    /** Sleep for the given duration, returning early if processing is terminated. */
+    private void sleepUnlessTerminated(long millis) {
+        long deadline = System.currentTimeMillis() + millis;
+        long remaining;
+        while (!terminateProcessing.get() && (remaining = deadline - System.currentTimeMillis()) > 0) {
+            try {
+                Thread.sleep(Math.min(remaining, 250));
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            }
+        }
     }
 
     private void submitPacketToListeners(AVPacket avPacket, Class<? extends DataBufferListener> listenerType) {
@@ -939,10 +1044,10 @@ public class MpegTsProcessor extends Thread {
 
         logger.debug("stopProcessingStream");
 
-        if (streamOpened) {
-            loop = false;
-            terminateProcessing.set(true);
-        }
+        // Not gated on streamOpened: during a reconnect attempt the stream is closed,
+        // and the flags must still be set or join() would wait on the retry loop forever.
+        loop = false;
+        terminateProcessing.set(true);
     }
 
     /**


### PR DESCRIPTION
Two fixes for the ffmpeg HLS camera pipeline found while chasing intermittent camera freeze/black-frame reports:

**1. RTSP reconnect, PTS rebase, wider live window**
- `MpegTsProcessor`: reconnects on RTSP stream drop instead of silently going stale.
- PTS rebasing across reconnects so HLS segment timestamps stay monotonic (a raw reconnect otherwise produces a PTS discontinuity that most players choke on).
- Widened the live HLS window so a brief upstream stall doesn't fall out of the playable range.

**2. Inactivity watchdog that never fired since inception**
`FFMPEGSensorBase`/`HLSControl`/`HlsStreamHandler`/`FileOutput`: the watchdog meant to detect a silently-stalled ffmpeg process (no new segments, no error) never actually triggered — traced to a check that could never observe a state transition. Fixed so a genuinely stuck stream now gets restarted instead of serving stale/frozen video indefinitely.

Companion viewer PR (Botts-Innovative-Research/oscar-viewer #280, updated) has the matching autoplay/live-window/recovery-detection changes, verified end-to-end via a `VideoStreamRecovery` cypress spec.